### PR TITLE
電容 PMOS 電流源 電感 與 更新牛頓法

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -94,9 +94,15 @@ void leftMouseButtonPressedEdge(int xGrid, int yGrid, UICircuit *circuit) {
     std::unique_ptr<UIElement> voltage =
         std::make_unique<VoltageSourceUIElement>(circuit, xGrid, yGrid, 2);
     circuit->addElement(voltage);
+  } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::A)) {
+    std::function<double(double)> v = [](double t) { return 2*sin(3 * t); };
+    std::unique_ptr<UIElement> voltage =
+        std::make_unique<AdjustableVoltageSourceUIElement>(circuit, xGrid,
+                                                           yGrid, v);
+    circuit->addElement(voltage);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::C)) {
-    std::unique_ptr<UIElement> capacitor =
-        std::make_unique<CapacitorUIElement>(circuit, xGrid, yGrid, 0.0000000001);
+    std::unique_ptr<UIElement> capacitor = std::make_unique<CapacitorUIElement>(
+        circuit, xGrid, yGrid, 0.0000000001);
     circuit->addElement(capacitor);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::L)) {
     std::unique_ptr<UIElement> bigResistor =
@@ -104,12 +110,12 @@ void leftMouseButtonPressedEdge(int xGrid, int yGrid, UICircuit *circuit) {
                                             1000000000000);
     circuit->addElement(bigResistor);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::Num1)) {
-    std::unique_ptr<UIElement> r800 = 
-      std::make_unique<ResistorUIElement>(circuit, xGrid, yGrid, 800);
+    std::unique_ptr<UIElement> r800 =
+        std::make_unique<ResistorUIElement>(circuit, xGrid, yGrid, 800);
     circuit->addElement(r800);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::Num2)) {
-    std::unique_ptr<UIElement> v18 = 
-      std::make_unique<VoltageSourceUIElement>(circuit, xGrid, yGrid, 1.8);
+    std::unique_ptr<UIElement> v18 =
+        std::make_unique<VoltageSourceUIElement>(circuit, xGrid, yGrid, 1.8);
     circuit->addElement(v18);
   }
 }
@@ -229,6 +235,38 @@ int main() {
   // uiCircuit.addElement(wire4);
   // uiCircuit.addElement(wire5);
   //
+
+  std::unique_ptr<UIElement> wire1 = std::make_unique<WireUIElement>(&uiCircuit, 5, 3, 8, 3);
+  std::unique_ptr<UIElement> srcV = std::make_unique<VoltageSourceUIElement>(&uiCircuit, 8, 4, 2);
+  std::unique_ptr<UIElement> groundSrc = std::make_unique<GroundUIElement>(&uiCircuit, 8, 5);
+  std::unique_ptr<UIElement> pmos = std::make_unique<PMOSUIElement>(&uiCircuit, 5, 4, K, VT, VA);
+  std::unique_ptr<UIElement> wirePMOS = std::make_unique<WireUIElement>(&uiCircuit, 5, 5, 5, 6);
+  std::unique_ptr<UIElement> wireNMOS = std::make_unique<WireUIElement>(&uiCircuit, 5, 6, 5, 7);
+  std::unique_ptr<UIElement> wireOut = std::make_unique<WireUIElement>(&uiCircuit, 5, 6, 7, 6);
+  std::unique_ptr<UIElement> rOut = std::make_unique<ResistorUIElement>(&uiCircuit, 7, 7, 1000);
+  std::unique_ptr<UIElement> groundOut = std::make_unique<GroundUIElement>(&uiCircuit, 7, 8);
+  std::unique_ptr<UIElement> nmos = std::make_unique<NMOSUIElement>(&uiCircuit, 5, 8, K, VT, VA);
+  std::unique_ptr<UIElement> groundNMOS = std::make_unique<GroundUIElement>(&uiCircuit, 5, 9);
+  std::unique_ptr<UIElement> wireGate = std::make_unique<WireUIElement>(&uiCircuit, 3, 4, 3, 8);
+  std::unique_ptr<UIElement> gateV = std::make_unique<AdjustableVoltageSourceUIElement>(&uiCircuit, 3, 9, [](double t) { return 2*sin(3*t); });
+  std::unique_ptr<UIElement> groundGate = std::make_unique<GroundUIElement>(&uiCircuit, 3, 10);
+
+   
+  uiCircuit.addElement(wire1);
+  uiCircuit.addElement(srcV);
+  uiCircuit.addElement(groundSrc);
+  uiCircuit.addElement(pmos);
+  uiCircuit.addElement(wirePMOS);
+  uiCircuit.addElement(wireNMOS);
+  uiCircuit.addElement(wireOut);
+  uiCircuit.addElement(rOut);
+  uiCircuit.addElement(groundOut);
+  uiCircuit.addElement(nmos);
+  uiCircuit.addElement(groundNMOS);
+  uiCircuit.addElement(wireGate);
+  uiCircuit.addElement(gateV);
+  uiCircuit.addElement(groundGate);
+
   sf::Vector2i mouseGridPos;
   sf::Vector2i mousePos;
 
@@ -241,7 +279,7 @@ int main() {
 
   window.setFramerateLimit(60);
   // simulationSpeed 0.001 - 1
-  double simulationSpeed = 1;
+  double simulationSpeed = 0.1;
   int simulationSpeedCounter = 0;
   while (window.isOpen()) {
     // Performed. Now perform GPU stuff...

--- a/main.cpp
+++ b/main.cpp
@@ -11,6 +11,7 @@
 #include <NMOSUIElement.h>
 #include <ResistorElement.h>
 #include <ResistorUIElement.h>
+#include <CapacitorUIElement.h>
 #include <SFML/Graphics.hpp>
 #include <SFML/Window/Cursor.hpp>
 #include <SFML/Window/Keyboard.hpp>
@@ -84,6 +85,9 @@ void leftMouseButtonPressedEdge(int xGrid, int yGrid, UICircuit *circuit) {
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::V)) {
     std::unique_ptr<UIElement> voltage = std::make_unique<VoltageSourceUIElement>(circuit, xGrid, yGrid, 2);
     circuit->addElement(voltage);
+  } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::C)) {
+    std::unique_ptr<UIElement> capacitor = std::make_unique<CapacitorUIElement>(circuit, xGrid, yGrid, 0.001);
+    circuit->addElement(capacitor);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::L)) {
     std::unique_ptr<UIElement> bigResistor = std::make_unique<ResistorUIElement>(circuit, xGrid, yGrid, 1000000000000);
     circuit->addElement(bigResistor);

--- a/main.cpp
+++ b/main.cpp
@@ -109,11 +109,11 @@ void leftMouseButtonPressedEdge(int xGrid, int yGrid, UICircuit *circuit) {
     circuit->addElement(current);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::C)) {
     std::unique_ptr<UIElement> capacitor = std::make_unique<CapacitorUIElement>(
-        circuit, xGrid, yGrid, 0.001);
+        circuit, xGrid, yGrid, 0.0001);
     circuit->addElement(capacitor);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::D)) {
     std::unique_ptr<UIElement> inductor = std::make_unique<InductorUIElement>(
-        circuit, xGrid, yGrid, 0.001);
+        circuit, xGrid, yGrid, 0.0001);
     circuit->addElement(inductor);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::L)) {
     std::unique_ptr<UIElement> bigResistor =

--- a/main.cpp
+++ b/main.cpp
@@ -8,9 +8,10 @@
 #include <Circuit.h>
 int Circuit::circuitCounter = 0;
 #include <CapacitorUIElement.h>
-#include <InductorUIElement.h>
 #include <CurrentSourceUIElement.h>
+#include <DiodeUIElement.h>
 #include <GroundUIElement.h>
+#include <InductorUIElement.h>
 #include <NMOSElement.h>
 #include <NMOSUIElement.h>
 #include <PMOSUIElement.h>
@@ -71,7 +72,7 @@ void leftMouseButtonPressedNegativeEdge(int xGrid, int yGrid,
 void leftMouseButtonPressedEdge(int xGrid, int yGrid, UICircuit *circuit) {
   if (sf::Keyboard::isKeyPressed(sf::Keyboard::R)) {
     std::unique_ptr<UIElement> resistor =
-        std::make_unique<ResistorUIElement>(circuit, xGrid, yGrid, 1);
+        std::make_unique<ResistorUIElement>(circuit, xGrid, yGrid, 1000);
     circuit->addElement(resistor);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::G)) {
     std::unique_ptr<UIElement> gnd =
@@ -92,28 +93,37 @@ void leftMouseButtonPressedEdge(int xGrid, int yGrid, UICircuit *circuit) {
     std::unique_ptr<UIElement> pmos =
         std::make_unique<PMOSUIElement>(circuit, xGrid, yGrid, K, VT, VA);
     circuit->addElement(pmos);
+  } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::D)) {
+    double Is = 6.9 * pow(10, -16);
+    double VTD = 0.025;
+    std::unique_ptr<UIElement> diode =
+        std::make_unique<DiodeUIElement>(circuit, xGrid, yGrid, Is, VTD);
+    circuit->addElement(diode);
+
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::V)) {
     std::unique_ptr<UIElement> voltage =
         std::make_unique<VoltageSourceUIElement>(circuit, xGrid, yGrid, 2);
     circuit->addElement(voltage);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::A)) {
-    std::function<double(double)> v = [](double t) { return 2 * sin(3 * t); };
+    std::function<double(double)> v = [](double t) { return 2 * sin(300000 * t); };
     std::unique_ptr<UIElement> voltage =
         std::make_unique<AdjustableVoltageSourceUIElement>(circuit, xGrid,
                                                            yGrid, v);
     circuit->addElement(voltage);
-  } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::I)) {
+  } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::I) &&
+             !sf::Keyboard::isKeyPressed(sf::Keyboard::LShift)) {
     double i = 1;
     std::unique_ptr<UIElement> current =
         std::make_unique<CurrentSourceUIElement>(circuit, xGrid, yGrid, i);
     circuit->addElement(current);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::C)) {
-    std::unique_ptr<UIElement> capacitor = std::make_unique<CapacitorUIElement>(
-        circuit, xGrid, yGrid, 0.0001);
+    std::unique_ptr<UIElement> capacitor =
+        std::make_unique<CapacitorUIElement>(circuit, xGrid, yGrid, 0.0001);
     circuit->addElement(capacitor);
-  } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::D)) {
-    std::unique_ptr<UIElement> inductor = std::make_unique<InductorUIElement>(
-        circuit, xGrid, yGrid, 0.0001);
+  } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::I) &&
+             sf::Keyboard::isKeyPressed(sf::Keyboard::LShift)) {
+    std::unique_ptr<UIElement> inductor =
+        std::make_unique<InductorUIElement>(circuit, xGrid, yGrid, 0.0001);
     circuit->addElement(inductor);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::L)) {
     std::unique_ptr<UIElement> bigResistor =

--- a/main.cpp
+++ b/main.cpp
@@ -85,6 +85,8 @@ void leftMouseButtonPressedEdge(int xGrid, int yGrid, UICircuit *circuit) {
         std::make_unique<NMOSUIElement>(circuit, xGrid, yGrid, K, VT, VA);
     circuit->addElement(nmos);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::P)) {
+    double KP = 5.5555556 * pow(10, -3);
+    double VTP = 0.4;
     std::unique_ptr<UIElement> pmos =
         std::make_unique<PMOSUIElement>(circuit, xGrid, yGrid, K, VT, VA);
     circuit->addElement(pmos);
@@ -94,7 +96,7 @@ void leftMouseButtonPressedEdge(int xGrid, int yGrid, UICircuit *circuit) {
     circuit->addElement(voltage);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::C)) {
     std::unique_ptr<UIElement> capacitor =
-        std::make_unique<CapacitorUIElement>(circuit, xGrid, yGrid, 0.001);
+        std::make_unique<CapacitorUIElement>(circuit, xGrid, yGrid, 0.0000000001);
     circuit->addElement(capacitor);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::L)) {
     std::unique_ptr<UIElement> bigResistor =
@@ -102,9 +104,13 @@ void leftMouseButtonPressedEdge(int xGrid, int yGrid, UICircuit *circuit) {
                                             1000000000000);
     circuit->addElement(bigResistor);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::Num1)) {
-    std::unique_ptr<UIElement> nmos =
-        std::make_unique<NMOSUIElement>(circuit, xGrid, yGrid, K, 2 * VT, VA);
-    circuit->addElement(nmos);
+    std::unique_ptr<UIElement> r800 = 
+      std::make_unique<ResistorUIElement>(circuit, xGrid, yGrid, 800);
+    circuit->addElement(r800);
+  } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::Num2)) {
+    std::unique_ptr<UIElement> v18 = 
+      std::make_unique<VoltageSourceUIElement>(circuit, xGrid, yGrid, 1.8);
+    circuit->addElement(v18);
   }
 }
 
@@ -171,58 +177,58 @@ int main() {
 
   std::cout << "UICircuit Size: " << sizeof(uiCircuit) << std::endl;
 
-  std::unique_ptr<UIElement> nmos1 =
-      std::make_unique<NMOSUIElement>(&uiCircuit, 4, 3, K, VT, VA);
-  std::unique_ptr<UIElement> nmos2 =
-      std::make_unique<NMOSUIElement>(&uiCircuit, 4, 8, K, VT, VA);
-  double v = 5;
-  std::unique_ptr<UIElement> voltsrc =
-      std::make_unique<VoltageSourceUIElement>(&uiCircuit, 6, 5, v);
-  std::function<double(double)> adjv = [](double t) {
-    return 5 * sin(t / 2) + 4;
-  };
-  std::unique_ptr<UIElement> adjvoltsrc =
-      std::make_unique<AdjustableVoltageSourceUIElement>(&uiCircuit, 5, 6,
-                                                         adjv);
-  std::unique_ptr<UIElement> r1 =
-      std::make_unique<ResistorUIElement>(&uiCircuit, 6, 3, 1000);
-  std::unique_ptr<UIElement> r2 =
-      std::make_unique<ResistorUIElement>(&uiCircuit, 4, 6, 1000);
-  std::unique_ptr<UIElement> gnd1 =
-      std::make_unique<GroundUIElement>(&uiCircuit, 4, 9);
-  std::unique_ptr<UIElement> gnd2 =
-      std::make_unique<GroundUIElement>(&uiCircuit, 5, 7);
-  std::unique_ptr<UIElement> gnd3 =
-      std::make_unique<GroundUIElement>(&uiCircuit, 6, 6);
-  std::unique_ptr<UIElement> gnd4 =
-      std::make_unique<GroundUIElement>(&uiCircuit, 4, 4);
-  std::unique_ptr<UIElement> wire1 =
-      std::make_unique<WireUIElement>(&uiCircuit, 4, 2, 6, 2);
-  std::unique_ptr<UIElement> wire2 =
-      std::make_unique<WireUIElement>(&uiCircuit, 2, 3, 2, 7);
-  std::unique_ptr<UIElement> wire3 =
-      std::make_unique<WireUIElement>(&uiCircuit, 2, 7, 2, 8);
-  std::unique_ptr<UIElement> wire4 =
-      std::make_unique<WireUIElement>(&uiCircuit, 2, 7, 4, 7);
-  std::unique_ptr<UIElement> wire5 =
-      std::make_unique<WireUIElement>(&uiCircuit, 4, 5, 5, 5);
-
-  uiCircuit.addElement(nmos1);
-  uiCircuit.addElement(nmos2);
-  uiCircuit.addElement(voltsrc);
-  uiCircuit.addElement(adjvoltsrc);
-  uiCircuit.addElement(r1);
-  uiCircuit.addElement(r2);
-  uiCircuit.addElement(gnd1);
-  uiCircuit.addElement(gnd2);
-  uiCircuit.addElement(gnd3);
-  uiCircuit.addElement(gnd4);
-  uiCircuit.addElement(wire1);
-  uiCircuit.addElement(wire2);
-  uiCircuit.addElement(wire3);
-  uiCircuit.addElement(wire4);
-  uiCircuit.addElement(wire5);
-
+  // std::unique_ptr<UIElement> nmos1 =
+  //     std::make_unique<NMOSUIElement>(&uiCircuit, 4, 3, K, VT, VA);
+  // std::unique_ptr<UIElement> nmos2 =
+  //     std::make_unique<NMOSUIElement>(&uiCircuit, 4, 8, K, VT, VA);
+  // double v = 5;
+  // std::unique_ptr<UIElement> voltsrc =
+  //     std::make_unique<VoltageSourceUIElement>(&uiCircuit, 6, 5, v);
+  // std::function<double(double)> adjv = [](double t) {
+  //   return 5 * sin(t / 2) + 4;
+  // };
+  // std::unique_ptr<UIElement> adjvoltsrc =
+  //     std::make_unique<AdjustableVoltageSourceUIElement>(&uiCircuit, 5, 6,
+  //                                                        adjv);
+  // std::unique_ptr<UIElement> r1 =
+  //     std::make_unique<ResistorUIElement>(&uiCircuit, 6, 3, 1000);
+  // std::unique_ptr<UIElement> r2 =
+  //     std::make_unique<ResistorUIElement>(&uiCircuit, 4, 6, 1000);
+  // std::unique_ptr<UIElement> gnd1 =
+  //     std::make_unique<GroundUIElement>(&uiCircuit, 4, 9);
+  // std::unique_ptr<UIElement> gnd2 =
+  //     std::make_unique<GroundUIElement>(&uiCircuit, 5, 7);
+  // std::unique_ptr<UIElement> gnd3 =
+  //     std::make_unique<GroundUIElement>(&uiCircuit, 6, 6);
+  // std::unique_ptr<UIElement> gnd4 =
+  //     std::make_unique<GroundUIElement>(&uiCircuit, 4, 4);
+  // std::unique_ptr<UIElement> wire1 =
+  //     std::make_unique<WireUIElement>(&uiCircuit, 4, 2, 6, 2);
+  // std::unique_ptr<UIElement> wire2 =
+  //     std::make_unique<WireUIElement>(&uiCircuit, 2, 3, 2, 7);
+  // std::unique_ptr<UIElement> wire3 =
+  //     std::make_unique<WireUIElement>(&uiCircuit, 2, 7, 2, 8);
+  // std::unique_ptr<UIElement> wire4 =
+  //     std::make_unique<WireUIElement>(&uiCircuit, 2, 7, 4, 7);
+  // std::unique_ptr<UIElement> wire5 =
+  //     std::make_unique<WireUIElement>(&uiCircuit, 4, 5, 5, 5);
+  //
+  // uiCircuit.addElement(nmos1);
+  // uiCircuit.addElement(nmos2);
+  // uiCircuit.addElement(voltsrc);
+  // uiCircuit.addElement(adjvoltsrc);
+  // uiCircuit.addElement(r1);
+  // uiCircuit.addElement(r2);
+  // uiCircuit.addElement(gnd1);
+  // uiCircuit.addElement(gnd2);
+  // uiCircuit.addElement(gnd3);
+  // uiCircuit.addElement(gnd4);
+  // uiCircuit.addElement(wire1);
+  // uiCircuit.addElement(wire2);
+  // uiCircuit.addElement(wire3);
+  // uiCircuit.addElement(wire4);
+  // uiCircuit.addElement(wire5);
+  //
   sf::Vector2i mouseGridPos;
   sf::Vector2i mousePos;
 

--- a/main.cpp
+++ b/main.cpp
@@ -6,6 +6,7 @@
 #include <AdjustableVoltageSourceElement.h>
 #include <AdjustableVoltageSourceUIElement.h>
 #include <Circuit.h>
+int Circuit::circuitCounter = 0;
 #include <GroundUIElement.h>
 #include <NMOSElement.h>
 #include <NMOSUIElement.h>
@@ -161,57 +162,57 @@ int main() {
 
   std::cout << "UICircuit Size: " << sizeof(uiCircuit) << std::endl;
 
-  // std::unique_ptr<UIElement> nmos1 =
-  //     std::make_unique<NMOSUIElement>(&uiCircuit, 4, 3, K, VT, VA);
-  // std::unique_ptr<UIElement> nmos2 =
-  //     std::make_unique<NMOSUIElement>(&uiCircuit, 4, 8, K, VT, VA);
-  // double v = 5;
-  // std::unique_ptr<UIElement> voltsrc =
-  //     std::make_unique<VoltageSourceUIElement>(&uiCircuit, 6, 5, v);
-  // std::function<double(double)> adjv = [](double t) {
-  //   return 5 * sin(t / 2) + 4;
-  // };
-  // std::unique_ptr<UIElement> adjvoltsrc =
-  //     std::make_unique<AdjustableVoltageSourceUIElement>(&uiCircuit, 5, 6,
-  //                                                        adjv);
-  // std::unique_ptr<UIElement> r1 =
-  //     std::make_unique<ResistorUIElement>(&uiCircuit, 6, 3, 1000);
-  // std::unique_ptr<UIElement> r2 =
-  //     std::make_unique<ResistorUIElement>(&uiCircuit, 4, 6, 1000);
-  // std::unique_ptr<UIElement> gnd1 =
-  //     std::make_unique<GroundUIElement>(&uiCircuit, 4, 9);
-  // std::unique_ptr<UIElement> gnd2 =
-  //     std::make_unique<GroundUIElement>(&uiCircuit, 5, 7);
-  // std::unique_ptr<UIElement> gnd3 =
-  //     std::make_unique<GroundUIElement>(&uiCircuit, 6, 6);
-  // std::unique_ptr<UIElement> gnd4 =
-  //     std::make_unique<GroundUIElement>(&uiCircuit, 4, 4);
-  // std::unique_ptr<UIElement> wire1 =
-  //     std::make_unique<WireUIElement>(&uiCircuit, 4, 2, 6, 2);
-  // std::unique_ptr<UIElement> wire2 =
-  //     std::make_unique<WireUIElement>(&uiCircuit, 2, 3, 2, 7);
-  // std::unique_ptr<UIElement> wire3 =
-  //     std::make_unique<WireUIElement>(&uiCircuit, 2, 7, 2, 8);
-  // std::unique_ptr<UIElement> wire4 =
-  //     std::make_unique<WireUIElement>(&uiCircuit, 2, 7, 4, 7);
-  // std::unique_ptr<UIElement> wire5 =
-  //     std::make_unique<WireUIElement>(&uiCircuit, 4, 5, 5, 5);
-  //
-  // uiCircuit.addElement(nmos1);
-  // uiCircuit.addElement(nmos2);
-  // uiCircuit.addElement(voltsrc);
-  // uiCircuit.addElement(adjvoltsrc);
-  // uiCircuit.addElement(r1);
-  // uiCircuit.addElement(r2);
-  // uiCircuit.addElement(gnd1);
-  // uiCircuit.addElement(gnd2);
-  // uiCircuit.addElement(gnd3);
-  // uiCircuit.addElement(gnd4);
-  // uiCircuit.addElement(wire1);
-  // uiCircuit.addElement(wire2);
-  // uiCircuit.addElement(wire3);
-  // uiCircuit.addElement(wire4);
-  // uiCircuit.addElement(wire5);
+  std::unique_ptr<UIElement> nmos1 =
+      std::make_unique<NMOSUIElement>(&uiCircuit, 4, 3, K, VT, VA);
+  std::unique_ptr<UIElement> nmos2 =
+      std::make_unique<NMOSUIElement>(&uiCircuit, 4, 8, K, VT, VA);
+  double v = 5;
+  std::unique_ptr<UIElement> voltsrc =
+      std::make_unique<VoltageSourceUIElement>(&uiCircuit, 6, 5, v);
+  std::function<double(double)> adjv = [](double t) {
+    return 5 * sin(t / 2) + 4;
+  };
+  std::unique_ptr<UIElement> adjvoltsrc =
+      std::make_unique<AdjustableVoltageSourceUIElement>(&uiCircuit, 5, 6,
+                                                         adjv);
+  std::unique_ptr<UIElement> r1 =
+      std::make_unique<ResistorUIElement>(&uiCircuit, 6, 3, 1000);
+  std::unique_ptr<UIElement> r2 =
+      std::make_unique<ResistorUIElement>(&uiCircuit, 4, 6, 1000);
+  std::unique_ptr<UIElement> gnd1 =
+      std::make_unique<GroundUIElement>(&uiCircuit, 4, 9);
+  std::unique_ptr<UIElement> gnd2 =
+      std::make_unique<GroundUIElement>(&uiCircuit, 5, 7);
+  std::unique_ptr<UIElement> gnd3 =
+      std::make_unique<GroundUIElement>(&uiCircuit, 6, 6);
+  std::unique_ptr<UIElement> gnd4 =
+      std::make_unique<GroundUIElement>(&uiCircuit, 4, 4);
+  std::unique_ptr<UIElement> wire1 =
+      std::make_unique<WireUIElement>(&uiCircuit, 4, 2, 6, 2);
+  std::unique_ptr<UIElement> wire2 =
+      std::make_unique<WireUIElement>(&uiCircuit, 2, 3, 2, 7);
+  std::unique_ptr<UIElement> wire3 =
+      std::make_unique<WireUIElement>(&uiCircuit, 2, 7, 2, 8);
+  std::unique_ptr<UIElement> wire4 =
+      std::make_unique<WireUIElement>(&uiCircuit, 2, 7, 4, 7);
+  std::unique_ptr<UIElement> wire5 =
+      std::make_unique<WireUIElement>(&uiCircuit, 4, 5, 5, 5);
+
+  uiCircuit.addElement(nmos1);
+  uiCircuit.addElement(nmos2);
+  uiCircuit.addElement(voltsrc);
+  uiCircuit.addElement(adjvoltsrc);
+  uiCircuit.addElement(r1);
+  uiCircuit.addElement(r2);
+  uiCircuit.addElement(gnd1);
+  uiCircuit.addElement(gnd2);
+  uiCircuit.addElement(gnd3);
+  uiCircuit.addElement(gnd4);
+  uiCircuit.addElement(wire1);
+  uiCircuit.addElement(wire2);
+  uiCircuit.addElement(wire3);
+  uiCircuit.addElement(wire4);
+  uiCircuit.addElement(wire5);
 
   sf::Vector2i mouseGridPos;
   sf::Vector2i mousePos;
@@ -335,13 +336,14 @@ int main() {
     endButton.update(sf::Vector2f(sf::Mouse::getPosition(window)));
     // NMOSUIElement *nmos1UIElement = (NMOSUIElement
     // *)uiCircuit.getUIElement(0); NMOSUIElement *nmos2UIElement =
-    // (NMOSUIElement *)uiCircuit.getUIElement(1); text.setString(
+    // (NMOSUIElement *)uiCircuit.getUIElement(1); 
+    // text.setString(
     //     "vg: " + std::to_string(nmosUIElement->getShownPinGVolt()) +
     //     " | vd: " + std::to_string(nmosUIElement->getShownPinDVolt()) +
     //     " | vs: " + std::to_string(nmosUIElement->getShownPinSVolt()) +
     //     " | i: " + std::to_string(nmosUIElement->getShownId()) +
     //     " | t: " + std::to_string(uiCircuit.getTime()));
-    //
+
 
     text.setString(
         "FPS: " + std::to_string(fps) +

--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,7 @@
 #include <Circuit.h>
 int Circuit::circuitCounter = 0;
 #include <CapacitorUIElement.h>
+#include <CurrentSourceUIElement.h>
 #include <GroundUIElement.h>
 #include <NMOSElement.h>
 #include <NMOSUIElement.h>
@@ -95,11 +96,16 @@ void leftMouseButtonPressedEdge(int xGrid, int yGrid, UICircuit *circuit) {
         std::make_unique<VoltageSourceUIElement>(circuit, xGrid, yGrid, 2);
     circuit->addElement(voltage);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::A)) {
-    std::function<double(double)> v = [](double t) { return 2*sin(3 * t); };
+    std::function<double(double)> v = [](double t) { return 2 * sin(3 * t); };
     std::unique_ptr<UIElement> voltage =
         std::make_unique<AdjustableVoltageSourceUIElement>(circuit, xGrid,
                                                            yGrid, v);
     circuit->addElement(voltage);
+  } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::I)) {
+    double i = 1;
+    std::unique_ptr<UIElement> current =
+        std::make_unique<CurrentSourceUIElement>(circuit, xGrid, yGrid, i);
+    circuit->addElement(current);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::C)) {
     std::unique_ptr<UIElement> capacitor = std::make_unique<CapacitorUIElement>(
         circuit, xGrid, yGrid, 0.0000000001);
@@ -236,22 +242,36 @@ int main() {
   // uiCircuit.addElement(wire5);
   //
 
-  std::unique_ptr<UIElement> wire1 = std::make_unique<WireUIElement>(&uiCircuit, 5, 3, 8, 3);
-  std::unique_ptr<UIElement> srcV = std::make_unique<VoltageSourceUIElement>(&uiCircuit, 8, 4, 2);
-  std::unique_ptr<UIElement> groundSrc = std::make_unique<GroundUIElement>(&uiCircuit, 8, 5);
-  std::unique_ptr<UIElement> pmos = std::make_unique<PMOSUIElement>(&uiCircuit, 5, 4, K, VT, VA);
-  std::unique_ptr<UIElement> wirePMOS = std::make_unique<WireUIElement>(&uiCircuit, 5, 5, 5, 6);
-  std::unique_ptr<UIElement> wireNMOS = std::make_unique<WireUIElement>(&uiCircuit, 5, 6, 5, 7);
-  std::unique_ptr<UIElement> wireOut = std::make_unique<WireUIElement>(&uiCircuit, 5, 6, 7, 6);
-  std::unique_ptr<UIElement> rOut = std::make_unique<ResistorUIElement>(&uiCircuit, 7, 7, 1000);
-  std::unique_ptr<UIElement> groundOut = std::make_unique<GroundUIElement>(&uiCircuit, 7, 8);
-  std::unique_ptr<UIElement> nmos = std::make_unique<NMOSUIElement>(&uiCircuit, 5, 8, K, VT, VA);
-  std::unique_ptr<UIElement> groundNMOS = std::make_unique<GroundUIElement>(&uiCircuit, 5, 9);
-  std::unique_ptr<UIElement> wireGate = std::make_unique<WireUIElement>(&uiCircuit, 3, 4, 3, 8);
-  std::unique_ptr<UIElement> gateV = std::make_unique<AdjustableVoltageSourceUIElement>(&uiCircuit, 3, 9, [](double t) { return 2*sin(3*t); });
-  std::unique_ptr<UIElement> groundGate = std::make_unique<GroundUIElement>(&uiCircuit, 3, 10);
+  std::unique_ptr<UIElement> wire1 =
+      std::make_unique<WireUIElement>(&uiCircuit, 5, 3, 8, 3);
+  std::unique_ptr<UIElement> srcV =
+      std::make_unique<VoltageSourceUIElement>(&uiCircuit, 8, 4, 2);
+  std::unique_ptr<UIElement> groundSrc =
+      std::make_unique<GroundUIElement>(&uiCircuit, 8, 5);
+  std::unique_ptr<UIElement> pmos =
+      std::make_unique<PMOSUIElement>(&uiCircuit, 5, 4, K, VT, VA);
+  std::unique_ptr<UIElement> wirePMOS =
+      std::make_unique<WireUIElement>(&uiCircuit, 5, 5, 5, 6);
+  std::unique_ptr<UIElement> wireNMOS =
+      std::make_unique<WireUIElement>(&uiCircuit, 5, 6, 5, 7);
+  std::unique_ptr<UIElement> wireOut =
+      std::make_unique<WireUIElement>(&uiCircuit, 5, 6, 7, 6);
+  std::unique_ptr<UIElement> rOut =
+      std::make_unique<ResistorUIElement>(&uiCircuit, 7, 7, 1000);
+  std::unique_ptr<UIElement> groundOut =
+      std::make_unique<GroundUIElement>(&uiCircuit, 7, 8);
+  std::unique_ptr<UIElement> nmos =
+      std::make_unique<NMOSUIElement>(&uiCircuit, 5, 8, K, VT, VA);
+  std::unique_ptr<UIElement> groundNMOS =
+      std::make_unique<GroundUIElement>(&uiCircuit, 5, 9);
+  std::unique_ptr<UIElement> wireGate =
+      std::make_unique<WireUIElement>(&uiCircuit, 3, 4, 3, 8);
+  std::unique_ptr<UIElement> gateV =
+      std::make_unique<AdjustableVoltageSourceUIElement>(
+          &uiCircuit, 3, 9, [](double t) { return 2 * sin(3 * t); });
+  std::unique_ptr<UIElement> groundGate =
+      std::make_unique<GroundUIElement>(&uiCircuit, 3, 10);
 
-   
   uiCircuit.addElement(wire1);
   uiCircuit.addElement(srcV);
   uiCircuit.addElement(groundSrc);

--- a/main.cpp
+++ b/main.cpp
@@ -109,11 +109,11 @@ void leftMouseButtonPressedEdge(int xGrid, int yGrid, UICircuit *circuit) {
     circuit->addElement(current);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::C)) {
     std::unique_ptr<UIElement> capacitor = std::make_unique<CapacitorUIElement>(
-        circuit, xGrid, yGrid, 0.1);
+        circuit, xGrid, yGrid, 0.001);
     circuit->addElement(capacitor);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::D)) {
     std::unique_ptr<UIElement> inductor = std::make_unique<InductorUIElement>(
-        circuit, xGrid, yGrid, 0.1);
+        circuit, xGrid, yGrid, 0.001);
     circuit->addElement(inductor);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::L)) {
     std::unique_ptr<UIElement> bigResistor =

--- a/main.cpp
+++ b/main.cpp
@@ -7,12 +7,13 @@
 #include <AdjustableVoltageSourceUIElement.h>
 #include <Circuit.h>
 int Circuit::circuitCounter = 0;
+#include <CapacitorUIElement.h>
 #include <GroundUIElement.h>
 #include <NMOSElement.h>
 #include <NMOSUIElement.h>
+#include <PMOSUIElement.h>
 #include <ResistorElement.h>
 #include <ResistorUIElement.h>
-#include <CapacitorUIElement.h>
 #include <SFML/Graphics.hpp>
 #include <SFML/Window/Cursor.hpp>
 #include <SFML/Window/Keyboard.hpp>
@@ -83,18 +84,26 @@ void leftMouseButtonPressedEdge(int xGrid, int yGrid, UICircuit *circuit) {
     std::unique_ptr<UIElement> nmos =
         std::make_unique<NMOSUIElement>(circuit, xGrid, yGrid, K, VT, VA);
     circuit->addElement(nmos);
+  } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::P)) {
+    std::unique_ptr<UIElement> pmos =
+        std::make_unique<PMOSUIElement>(circuit, xGrid, yGrid, K, VT, VA);
+    circuit->addElement(pmos);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::V)) {
-    std::unique_ptr<UIElement> voltage = std::make_unique<VoltageSourceUIElement>(circuit, xGrid, yGrid, 2);
+    std::unique_ptr<UIElement> voltage =
+        std::make_unique<VoltageSourceUIElement>(circuit, xGrid, yGrid, 2);
     circuit->addElement(voltage);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::C)) {
-    std::unique_ptr<UIElement> capacitor = std::make_unique<CapacitorUIElement>(circuit, xGrid, yGrid, 0.001);
+    std::unique_ptr<UIElement> capacitor =
+        std::make_unique<CapacitorUIElement>(circuit, xGrid, yGrid, 0.001);
     circuit->addElement(capacitor);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::L)) {
-    std::unique_ptr<UIElement> bigResistor = std::make_unique<ResistorUIElement>(circuit, xGrid, yGrid, 1000000000000);
+    std::unique_ptr<UIElement> bigResistor =
+        std::make_unique<ResistorUIElement>(circuit, xGrid, yGrid,
+                                            1000000000000);
     circuit->addElement(bigResistor);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::Num1)) {
     std::unique_ptr<UIElement> nmos =
-        std::make_unique<NMOSUIElement>(circuit, xGrid, yGrid, K, 2*VT, VA);
+        std::make_unique<NMOSUIElement>(circuit, xGrid, yGrid, K, 2 * VT, VA);
     circuit->addElement(nmos);
   }
 }
@@ -336,14 +345,13 @@ int main() {
     endButton.update(sf::Vector2f(sf::Mouse::getPosition(window)));
     // NMOSUIElement *nmos1UIElement = (NMOSUIElement
     // *)uiCircuit.getUIElement(0); NMOSUIElement *nmos2UIElement =
-    // (NMOSUIElement *)uiCircuit.getUIElement(1); 
+    // (NMOSUIElement *)uiCircuit.getUIElement(1);
     // text.setString(
     //     "vg: " + std::to_string(nmosUIElement->getShownPinGVolt()) +
     //     " | vd: " + std::to_string(nmosUIElement->getShownPinDVolt()) +
     //     " | vs: " + std::to_string(nmosUIElement->getShownPinSVolt()) +
     //     " | i: " + std::to_string(nmosUIElement->getShownId()) +
     //     " | t: " + std::to_string(uiCircuit.getTime()));
-
 
     text.setString(
         "FPS: " + std::to_string(fps) +

--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,7 @@
 #include <Circuit.h>
 int Circuit::circuitCounter = 0;
 #include <CapacitorUIElement.h>
+#include <InductorUIElement.h>
 #include <CurrentSourceUIElement.h>
 #include <GroundUIElement.h>
 #include <NMOSElement.h>
@@ -70,7 +71,7 @@ void leftMouseButtonPressedNegativeEdge(int xGrid, int yGrid,
 void leftMouseButtonPressedEdge(int xGrid, int yGrid, UICircuit *circuit) {
   if (sf::Keyboard::isKeyPressed(sf::Keyboard::R)) {
     std::unique_ptr<UIElement> resistor =
-        std::make_unique<ResistorUIElement>(circuit, xGrid, yGrid, 4000);
+        std::make_unique<ResistorUIElement>(circuit, xGrid, yGrid, 0.01);
     circuit->addElement(resistor);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::G)) {
     std::unique_ptr<UIElement> gnd =
@@ -108,8 +109,12 @@ void leftMouseButtonPressedEdge(int xGrid, int yGrid, UICircuit *circuit) {
     circuit->addElement(current);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::C)) {
     std::unique_ptr<UIElement> capacitor = std::make_unique<CapacitorUIElement>(
-        circuit, xGrid, yGrid, 0.0000000001);
+        circuit, xGrid, yGrid, 0.1);
     circuit->addElement(capacitor);
+  } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::D)) {
+    std::unique_ptr<UIElement> inductor = std::make_unique<InductorUIElement>(
+        circuit, xGrid, yGrid, 0.1);
+    circuit->addElement(inductor);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::L)) {
     std::unique_ptr<UIElement> bigResistor =
         std::make_unique<ResistorUIElement>(circuit, xGrid, yGrid,
@@ -242,51 +247,51 @@ int main() {
   // uiCircuit.addElement(wire5);
   //
 
-  std::unique_ptr<UIElement> wire1 =
-      std::make_unique<WireUIElement>(&uiCircuit, 5, 3, 8, 3);
-  std::unique_ptr<UIElement> srcV =
-      std::make_unique<VoltageSourceUIElement>(&uiCircuit, 8, 4, 2);
-  std::unique_ptr<UIElement> groundSrc =
-      std::make_unique<GroundUIElement>(&uiCircuit, 8, 5);
-  std::unique_ptr<UIElement> pmos =
-      std::make_unique<PMOSUIElement>(&uiCircuit, 5, 4, K, VT, VA);
-  std::unique_ptr<UIElement> wirePMOS =
-      std::make_unique<WireUIElement>(&uiCircuit, 5, 5, 5, 6);
-  std::unique_ptr<UIElement> wireNMOS =
-      std::make_unique<WireUIElement>(&uiCircuit, 5, 6, 5, 7);
-  std::unique_ptr<UIElement> wireOut =
-      std::make_unique<WireUIElement>(&uiCircuit, 5, 6, 7, 6);
-  std::unique_ptr<UIElement> rOut =
-      std::make_unique<ResistorUIElement>(&uiCircuit, 7, 7, 1000);
-  std::unique_ptr<UIElement> groundOut =
-      std::make_unique<GroundUIElement>(&uiCircuit, 7, 8);
-  std::unique_ptr<UIElement> nmos =
-      std::make_unique<NMOSUIElement>(&uiCircuit, 5, 8, K, VT, VA);
-  std::unique_ptr<UIElement> groundNMOS =
-      std::make_unique<GroundUIElement>(&uiCircuit, 5, 9);
-  std::unique_ptr<UIElement> wireGate =
-      std::make_unique<WireUIElement>(&uiCircuit, 3, 4, 3, 8);
-  std::unique_ptr<UIElement> gateV =
-      std::make_unique<AdjustableVoltageSourceUIElement>(
-          &uiCircuit, 3, 9, [](double t) { return 2 * sin(3 * t); });
-  std::unique_ptr<UIElement> groundGate =
-      std::make_unique<GroundUIElement>(&uiCircuit, 3, 10);
-
-  uiCircuit.addElement(wire1);
-  uiCircuit.addElement(srcV);
-  uiCircuit.addElement(groundSrc);
-  uiCircuit.addElement(pmos);
-  uiCircuit.addElement(wirePMOS);
-  uiCircuit.addElement(wireNMOS);
-  uiCircuit.addElement(wireOut);
-  uiCircuit.addElement(rOut);
-  uiCircuit.addElement(groundOut);
-  uiCircuit.addElement(nmos);
-  uiCircuit.addElement(groundNMOS);
-  uiCircuit.addElement(wireGate);
-  uiCircuit.addElement(gateV);
-  uiCircuit.addElement(groundGate);
-
+  // std::unique_ptr<UIElement> wire1 =
+  //     std::make_unique<WireUIElement>(&uiCircuit, 5, 3, 8, 3);
+  // std::unique_ptr<UIElement> srcV =
+  //     std::make_unique<VoltageSourceUIElement>(&uiCircuit, 8, 4, 2);
+  // std::unique_ptr<UIElement> groundSrc =
+  //     std::make_unique<GroundUIElement>(&uiCircuit, 8, 5);
+  // std::unique_ptr<UIElement> pmos =
+  //     std::make_unique<PMOSUIElement>(&uiCircuit, 5, 4, K, VT, VA);
+  // std::unique_ptr<UIElement> wirePMOS =
+  //     std::make_unique<WireUIElement>(&uiCircuit, 5, 5, 5, 6);
+  // std::unique_ptr<UIElement> wireNMOS =
+  //     std::make_unique<WireUIElement>(&uiCircuit, 5, 6, 5, 7);
+  // std::unique_ptr<UIElement> wireOut =
+  //     std::make_unique<WireUIElement>(&uiCircuit, 5, 6, 7, 6);
+  // std::unique_ptr<UIElement> rOut =
+  //     std::make_unique<ResistorUIElement>(&uiCircuit, 7, 7, 1000);
+  // std::unique_ptr<UIElement> groundOut =
+  //     std::make_unique<GroundUIElement>(&uiCircuit, 7, 8);
+  // std::unique_ptr<UIElement> nmos =
+  //     std::make_unique<NMOSUIElement>(&uiCircuit, 5, 8, K, VT, VA);
+  // std::unique_ptr<UIElement> groundNMOS =
+  //     std::make_unique<GroundUIElement>(&uiCircuit, 5, 9);
+  // std::unique_ptr<UIElement> wireGate =
+  //     std::make_unique<WireUIElement>(&uiCircuit, 3, 4, 3, 8);
+  // std::unique_ptr<UIElement> gateV =
+  //     std::make_unique<AdjustableVoltageSourceUIElement>(
+  //         &uiCircuit, 3, 9, [](double t) { return 2 * sin(3 * t); });
+  // std::unique_ptr<UIElement> groundGate =
+  //     std::make_unique<GroundUIElement>(&uiCircuit, 3, 10);
+  //
+  // uiCircuit.addElement(wire1);
+  // uiCircuit.addElement(srcV);
+  // uiCircuit.addElement(groundSrc);
+  // uiCircuit.addElement(pmos);
+  // uiCircuit.addElement(wirePMOS);
+  // uiCircuit.addElement(wireNMOS);
+  // uiCircuit.addElement(wireOut);
+  // uiCircuit.addElement(rOut);
+  // uiCircuit.addElement(groundOut);
+  // uiCircuit.addElement(nmos);
+  // uiCircuit.addElement(groundNMOS);
+  // uiCircuit.addElement(wireGate);
+  // uiCircuit.addElement(gateV);
+  // uiCircuit.addElement(groundGate);
+  //
   sf::Vector2i mouseGridPos;
   sf::Vector2i mousePos;
 
@@ -297,9 +302,9 @@ int main() {
       std::chrono::high_resolution_clock::now();
   float fps;
 
-  window.setFramerateLimit(60);
+  window.setFramerateLimit(500);
   // simulationSpeed 0.001 - 1
-  double simulationSpeed = 0.1;
+  double simulationSpeed = 1;
   int simulationSpeedCounter = 0;
   while (window.isOpen()) {
     // Performed. Now perform GPU stuff...

--- a/main.cpp
+++ b/main.cpp
@@ -71,7 +71,7 @@ void leftMouseButtonPressedNegativeEdge(int xGrid, int yGrid,
 void leftMouseButtonPressedEdge(int xGrid, int yGrid, UICircuit *circuit) {
   if (sf::Keyboard::isKeyPressed(sf::Keyboard::R)) {
     std::unique_ptr<UIElement> resistor =
-        std::make_unique<ResistorUIElement>(circuit, xGrid, yGrid, 0.01);
+        std::make_unique<ResistorUIElement>(circuit, xGrid, yGrid, 1);
     circuit->addElement(resistor);
   } else if (sf::Keyboard::isKeyPressed(sf::Keyboard::G)) {
     std::unique_ptr<UIElement> gnd =
@@ -302,7 +302,7 @@ int main() {
       std::chrono::high_resolution_clock::now();
   float fps;
 
-  window.setFramerateLimit(500);
+  window.setFramerateLimit(1000);
   // simulationSpeed 0.001 - 1
   double simulationSpeed = 1;
   int simulationSpeedCounter = 0;

--- a/src/Circuit.h
+++ b/src/Circuit.h
@@ -244,6 +244,9 @@ private:
   double deltaT;
   int MAX_NODE_ID;
   int MAX_MATRIX_SIZE;
+public:
+  int getMaxNodeID() { return MAX_NODE_ID; }
+  int getDeltaT() { return deltaT; }
 
 public:
   static int circuitCounter;

--- a/src/Circuit.h
+++ b/src/Circuit.h
@@ -110,7 +110,7 @@ public:
     std::cout << deltaV << std::endl;
 
     // TODO: Find points deltaV too aggressive
-    double maxDeltaV = 1;
+    double maxDeltaV = 100;
     for (int index = 0; index < MAX_MATRIX_SIZE; index++) {
       if (fabs(deltaV(index)) > maxDeltaV) {
         bool negative = false;

--- a/src/Circuit.h
+++ b/src/Circuit.h
@@ -99,7 +99,7 @@ public:
 
     // std::cout << "f matrix success" << std::endl;
     // J matrix
-    double delta = 0.000001;
+    double delta = 0.0001;
     Eigen::MatrixXd dupV = v.replicate(1, MAX_MATRIX_SIZE);
     Eigen::MatrixXd vWithDelta =
         Eigen::MatrixXd::Identity(MAX_MATRIX_SIZE, MAX_MATRIX_SIZE);
@@ -173,6 +173,7 @@ public:
       std::cout << "J" << std::endl << j << std::endl;
       std::cout << "J inv:" << std::endl << j.inverse() << std::endl;
       std::cout << "F:" << std::endl << f << std::endl;
+      exit(1);
     } else {
       v += deltaV;
       *passed = true;
@@ -246,7 +247,7 @@ private:
   int MAX_MATRIX_SIZE;
 public:
   int getMaxNodeID() { return MAX_NODE_ID; }
-  int getDeltaT() { return deltaT; }
+  double getDeltaT() { return deltaT; }
 
 public:
   static int circuitCounter;

--- a/src/Circuit.h
+++ b/src/Circuit.h
@@ -40,9 +40,9 @@ public:
 
     for (CircuitElement *ele : elements) {
       // g matrix
-      ele->modifyGMatrix(circuit->g, circuit->v, circuit->MAX_NODE_ID, 0);
+      ele->modifyGMatrix(circuit->g, circuit->v, circuit->MAX_NODE_ID, 0, deltaT);
       // i matrix
-      ele->modifyIMatrix(circuit->i, circuit->v, circuit->MAX_NODE_ID, 0);
+      ele->modifyIMatrix(circuit->i, circuit->v, circuit->MAX_NODE_ID, 0, deltaT);
       // std::cout << "element success" << std::endl;
     }
 
@@ -67,9 +67,9 @@ public:
 
     for (CircuitElement *ele : elements) {
       // g matrix
-      ele->modifyGMatrix(g, v, MAX_NODE_ID, t);
+      ele->modifyGMatrix(g, v, MAX_NODE_ID, t, deltaT);
       // i matrix
-      ele->modifyIMatrix(i, v, MAX_NODE_ID, t);
+      ele->modifyIMatrix(i, v, MAX_NODE_ID, t, deltaT);
       // std::cout << "element success" << std::endl;
     }
 
@@ -106,8 +106,8 @@ public:
 
     // calculate deltaV
     Eigen::MatrixXd deltaV = -1 * ((j.inverse()) * f);
-    std::cout << "deltaV value:" << std::endl;
-    std::cout << deltaV << std::endl;
+    // std::cout << "deltaV value:" << std::endl;
+    // std::cout << deltaV << std::endl;
 
     // TODO: Find points deltaV too aggressive
     double maxDeltaV = 1;
@@ -117,7 +117,7 @@ public:
         if (deltaV(index) < 0)
           negative = true;
 
-        std::cout << "Index: " << index << " is too sensitive" << std::endl;
+        // std::cout << "Index: " << index << " is too sensitive" << std::endl;
         double fabsDeltaV = std::fabs(deltaV(index));
         double modifiedV = maxDeltaV + 1;
         while (true) {
@@ -132,10 +132,10 @@ public:
           modifiedV *= -1;
         }
 
-        std::cout << "Value updated from " << deltaV(index);
+        // std::cout << "Value updated from " << deltaV(index);
         deltaV(index) = modifiedV;
-        std::cout << " to " << deltaV(index) << std::endl;
-        std::cout << "floatingRootScale: " << floatingRootScale << std::endl;
+        // std::cout << " to " << deltaV(index) << std::endl;
+        // std::cout << "floatingRootScale: " << floatingRootScale << std::endl;
       }
     }
     // calculate new v
@@ -170,8 +170,8 @@ public:
 
     // print v
     // std::cout << "V0\nV1\nIx\nIY:" << std::endl;
-    std::cout << "V:" << std::endl;
-    std::cout << v << std::endl;
+    // std::cout << "V:" << std::endl;
+    // std::cout << v << std::endl;
     Eigen::MatrixXd iEvaluations = g * v - i;
     double sumOfIEvaluation = 0;
     double IEvaluationMax = 0;
@@ -183,9 +183,9 @@ public:
       sumOfIEvaluation += absIEvaluation;
     }
 
-    std::cout << "===============" << std::endl;
-    std::cout << "evaluation:" << std::endl;
-    std::cout << iEvaluations << std::endl;
+    // std::cout << "===============" << std::endl;
+    // std::cout << "evaluation:" << std::endl;
+    // std::cout << iEvaluations << std::endl;
     // std::cout << "sum of evaluation: " << std::endl;
     // std::cout << sumOfIEvaluation << std::endl;
 
@@ -217,7 +217,6 @@ public:
   double getVoltage(int PIN_ID) { return v(PIN_ID); }
   double *getVoltagePointer(int PIN_ID) { return &v(PIN_ID); }
   Eigen::MatrixXd &getVoltageMatrix() { return v; }
-
   double getTime() { return t; }
 
 private:

--- a/src/Circuit.h
+++ b/src/Circuit.h
@@ -152,9 +152,9 @@ public:
     // calculate new v
     // more drag means more iterations
     //
-    double maxDeltaLength = 0.001;
-    if (iteration != 1) {
-      maxDeltaLength = 10;
+    double maxDeltaLength = 0.01;
+    if (iteration == 1) {
+      maxDeltaLength = pow(MAX_MATRIX_SIZE*10, 0.5);
     }
 
     double normDeltaV = deltaV.norm();

--- a/src/Circuit.h
+++ b/src/Circuit.h
@@ -88,7 +88,7 @@ public:
 
     // std::cout << "f matrix success" << std::endl;
     // J matrix
-    double delta = 0.00000001;
+    double delta = 0.000001;
     Eigen::MatrixXd dupV = v.replicate(1, MAX_MATRIX_SIZE);
     Eigen::MatrixXd vWithDelta =
         Eigen::MatrixXd::Identity(MAX_MATRIX_SIZE, MAX_MATRIX_SIZE);
@@ -141,7 +141,7 @@ public:
     // calculate new v
     // more drag means more iterations
     //
-    double maxDeltaLength = 1;
+    double maxDeltaLength = 0.001;
     if (iteration != 1) {
       maxDeltaLength = 10;
     }

--- a/src/Circuit.h
+++ b/src/Circuit.h
@@ -100,7 +100,7 @@ public:
     // std::cout << "f matrix success" << std::endl;
     // J matrix
     
-    double delta = 0.001;
+    double delta = 0.0000001;
     Eigen::MatrixXd dupV = v.replicate(1, MAX_MATRIX_SIZE);
     Eigen::MatrixXd vWithDelta =
         Eigen::MatrixXd::Identity(MAX_MATRIX_SIZE, MAX_MATRIX_SIZE);
@@ -154,9 +154,9 @@ public:
     // calculate new v
     // more drag means more iterations
     //
-    double maxDeltaLength = 0.001;
+    double maxDeltaLength = 1;
     if (iteration == 1) {
-      maxDeltaLength = pow(MAX_MATRIX_SIZE*pow(10, 2), 0.5);
+      maxDeltaLength = pow(MAX_MATRIX_SIZE*pow(0.5, 2), 0.5);
     }
 
     double normDeltaV = deltaV.norm();

--- a/src/Circuit.h
+++ b/src/Circuit.h
@@ -99,7 +99,8 @@ public:
 
     // std::cout << "f matrix success" << std::endl;
     // J matrix
-    double delta = 0.0001;
+    
+    double delta = 0.001;
     Eigen::MatrixXd dupV = v.replicate(1, MAX_MATRIX_SIZE);
     Eigen::MatrixXd vWithDelta =
         Eigen::MatrixXd::Identity(MAX_MATRIX_SIZE, MAX_MATRIX_SIZE);
@@ -119,6 +120,7 @@ public:
     Eigen::MatrixXd deltaV = -1 * ((j.inverse()) * f);
     // std::cout << "deltaV value:" << std::endl;
     // std::cout << deltaV << std::endl;
+    
 
     // TODO: Find points deltaV too aggressive
     double maxDeltaV = 100;
@@ -152,9 +154,9 @@ public:
     // calculate new v
     // more drag means more iterations
     //
-    double maxDeltaLength = 0.01;
+    double maxDeltaLength = 0.001;
     if (iteration == 1) {
-      maxDeltaLength = pow(MAX_MATRIX_SIZE*10, 0.5);
+      maxDeltaLength = pow(MAX_MATRIX_SIZE*pow(10, 2), 0.5);
     }
 
     double normDeltaV = deltaV.norm();

--- a/src/CircuitElement.h
+++ b/src/CircuitElement.h
@@ -1,13 +1,20 @@
 #pragma once
 #include <eigen3/Eigen/Dense>
 
+class Circuit;
+
 class CircuitElement {
 public:
   CircuitElement() {}
   virtual ~CircuitElement() {}
   virtual int getVoltageSourceCount() = 0;
+  virtual void incTime(Circuit *circuit) = 0;
   virtual void modifyGMatrix(Eigen::MatrixXd &g, Eigen::MatrixXd &v,
                              int MAX_NODE_ID, double t, double deltaT) = 0;
   virtual void modifyIMatrix(Eigen::MatrixXd &i, Eigen::MatrixXd &v,
                              int MAX_NODE_ID, double t, double deltaT) = 0;
+
+protected:
+  // Bridge uiCircuitElement with renderable circuitElement
+  int uiElementID;
 };

--- a/src/CircuitElement.h
+++ b/src/CircuitElement.h
@@ -7,7 +7,7 @@ public:
   virtual ~CircuitElement() {}
   virtual int getVoltageSourceCount() = 0;
   virtual void modifyGMatrix(Eigen::MatrixXd &g, Eigen::MatrixXd &v,
-                             int MAX_NODE_ID, double t) = 0;
+                             int MAX_NODE_ID, double t, double deltaT) = 0;
   virtual void modifyIMatrix(Eigen::MatrixXd &i, Eigen::MatrixXd &v,
-                             int MAX_NODE_ID, double t) = 0;
+                             int MAX_NODE_ID, double t, double deltaT) = 0;
 };

--- a/src/Elements/AdjustableVoltageSourceElement.h
+++ b/src/Elements/AdjustableVoltageSourceElement.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Circuit.h"
 #include <CircuitElement.h>
 #include <memory>
 
@@ -42,6 +43,8 @@ public:
     i(MAX_NODE_ID + 1 + voltageSourceID) = this->v(t);
     // std::cout << "adjVoltageSourceISuccess" << std::endl;
   }
+
+  void incTime(Circuit* circuit) override {}
 
 private:
   std::function<double(double)> v;

--- a/src/Elements/AdjustableVoltageSourceElement.h
+++ b/src/Elements/AdjustableVoltageSourceElement.h
@@ -23,7 +23,7 @@ public:
   int getVoltageSourceCount() override { return 1; }
 
   void modifyGMatrix(Eigen::MatrixXd &g, Eigen::MatrixXd &v, int MAX_NODE_ID,
-                     double t) override {
+                     double t, double deltaT) override {
     if (pin1 != -1) {
       g(MAX_NODE_ID + 1 + voltageSourceID, pin1) = 1;
       g(pin1, MAX_NODE_ID + 1 + voltageSourceID) = 1;
@@ -38,7 +38,7 @@ public:
   }
 
   void modifyIMatrix(Eigen::MatrixXd &i, Eigen::MatrixXd &v, int MAX_NODE_ID,
-                     double t) override {
+                     double t, double deltaT) override {
     i(MAX_NODE_ID + 1 + voltageSourceID) = this->v(t);
     // std::cout << "adjVoltageSourceISuccess" << std::endl;
   }

--- a/src/Elements/CapacitorElement.h
+++ b/src/Elements/CapacitorElement.h
@@ -7,56 +7,67 @@ class CapacitorElement : public CircuitElement {
 private:
   double previousV = 0;
   double C;
-  int PIN_1, PIN_2;
+  int PIN_1, PIN_2, PIN_M;
+  int voltageSourceID;
+public:
+  int getVoltageSourceID() {
+    return voltageSourceID;
+  }
 
 public:
   int getPIN1() { return PIN_1; }
   int getPIN2() { return PIN_2; }
 
 public:
-  static std::unique_ptr<CapacitorElement> create(double C, double initialV,
-                                                  int PIN_1, int PIN_2) {
+  static std::unique_ptr<CapacitorElement>
+  create(double C, double initialV, int PIN_1, int PIN_2, int PIN_M, int voltageSourceID) {
     std::unique_ptr<CapacitorElement> cap =
-        std::make_unique<CapacitorElement>(C, initialV, PIN_1, PIN_2);
+        std::make_unique<CapacitorElement>(C, initialV, PIN_1, PIN_2, PIN_M, voltageSourceID);
     return std::move(cap);
   }
 
-  CapacitorElement(double C, double initialV, int PIN_1, int PIN_2) {
+  CapacitorElement(double C, double initialV, int PIN_1, int PIN_2, int PIN_M, int voltageSourceID) {
     this->C = C;
     previousV = initialV;
     this->PIN_1 = PIN_1;
     this->PIN_2 = PIN_2;
+    this->PIN_M = PIN_M;
+    this->voltageSourceID = voltageSourceID;
   }
 
 public:
-  int getVoltageSourceCount() override { return 0; }
+  int getVoltageSourceCount() override { return 1; }
 
   void modifyGMatrix(Eigen::MatrixXd &g, Eigen::MatrixXd &v, int MAX_NODE_ID,
                      double t, double deltaT) override {
-    double g0 = 1.0 / getInnerResistance(deltaT);
-    if (PIN_1 != -1)
-      g(PIN_1, PIN_1) += g0;
+    double g0 = getInnerConductance(deltaT, previousV, C);
     if (PIN_2 != -1)
       g(PIN_2, PIN_2) += g0;
-    if (PIN_1 != -1 && PIN_2 != -1) {
-      g(PIN_1, PIN_2) += -g0;
-      g(PIN_2, PIN_1) += -g0;
+    if (PIN_M != -1)
+      g(PIN_M, PIN_M) += g0;
+    if (PIN_2 != -1 && PIN_M != -1) {
+      g(PIN_2, PIN_M) += -g0;
+      g(PIN_M, PIN_2) += -g0;
     }
+
+    if (PIN_1 != -1) {
+      g(MAX_NODE_ID + 1 + voltageSourceID, PIN_1) = 1;
+      // std::cout << "success1" << std::endl;
+      g(PIN_1, MAX_NODE_ID + 1 + voltageSourceID) = 1;
+      // std::cout << "success2" << std::endl;
+    }
+
+    if (PIN_M != -1) {
+      g(MAX_NODE_ID + 1 + voltageSourceID, PIN_M) = -1;
+      g(PIN_M, MAX_NODE_ID + 1 + voltageSourceID) = -1;
+    }
+    
+    
   }
 
   void modifyIMatrix(Eigen::MatrixXd &i, Eigen::MatrixXd &v, int MAX_NODE_ID,
                      double t, double deltaT) override {
-    if (PIN_1 != -1) {
-      // ideq large DC signal current
-      // issd small signal current
-      i(PIN_1) += -getInnerISource(deltaT);
-    }
-
-    if (PIN_2 != -1) {
-      // ideq large DC signal current
-      // issd small signal current
-      i(PIN_2) += getInnerISource(deltaT);
-    }
+    i(MAX_NODE_ID + 1 + voltageSourceID) = getInnerVSource(deltaT, previousV, C);
   }
 
   void incTime(Circuit *circuit) override {
@@ -73,18 +84,16 @@ public:
     circuit->setCircuitID(Circuit::circuitCounter);
     Circuit::circuitCounter++;
     previousV = pin1Volt - pin2Volt;
-    // std::cout << "CID:" << circuit->getCircuitID() << "updatedP:" << previousV
-              // << std::endl;
+    // std::cout << "CID:" << circuit->getCircuitID() << "updatedP:" <<
+    // previousV
+    // << std::endl;
   }
 
 public:
-  double getInnerISource(double deltaT) {
-    return CapacitorElement::getInnerISource(deltaT, previousV, C);
+  static double getInnerVSource(double deltaT, double previousV, double C) {
+    return previousV;
   }
-  double getInnerResistance(double deltaT) { return CapacitorElement::getInnerResistance(deltaT, previousV, C); }
-
-  static double getInnerISource(double deltaT, double previousV, double C) {
-    return -previousV / CapacitorElement::getInnerResistance(deltaT, previousV, C);
+  static double getInnerConductance(double deltaT, double previousV, double C) {
+    return C / deltaT;
   }
-  static double getInnerResistance(double deltaT, double previousV, double C) { return deltaT / C; }
 };

--- a/src/Elements/CapacitorElement.h
+++ b/src/Elements/CapacitorElement.h
@@ -1,0 +1,69 @@
+#include "CircuitElement.h"
+#include <memory>
+
+class CapacitorElement : public CircuitElement {
+private:
+  double previousV = 0;
+  double C;
+  double deltaT;
+  int PIN_1, PIN_2;
+public:
+
+  int getPIN1() { return PIN_1; }
+  int getPIN2() { return PIN_2; }
+  double getDeltaT() { return deltaT; }
+
+public:
+  static std::unique_ptr<CapacitorElement>
+  create(double C, double initialV, int PIN_1, int PIN_2) {
+    std::unique_ptr<CapacitorElement> cap =
+        std::make_unique<CapacitorElement>(C, initialV, PIN_1, PIN_2);
+    return std::move(cap);
+  }
+
+  CapacitorElement(double C, double initialV, int PIN_1,
+                   int PIN_2) {
+    this->C = C;
+    previousV = initialV;
+    this->PIN_1 = PIN_1;
+    this->PIN_2 = PIN_2;
+  }
+
+public:
+  int getVoltageSourceCount() override { return 0; }
+
+  void modifyGMatrix(Eigen::MatrixXd &g, Eigen::MatrixXd &v, int MAX_NODE_ID,
+                     double t, double deltaT) override {
+    this->deltaT = deltaT;
+    double g0 = 1.0 / getInnerResistance(deltaT);
+    if (PIN_1 != -1)
+      g(PIN_1, PIN_1) += g0;
+    if (PIN_2 != -1)
+      g(PIN_2, PIN_2) += g0;
+    if (PIN_1 != -1 && PIN_2 != -1) {
+      g(PIN_1, PIN_2) += -g0;
+      g(PIN_2, PIN_1) += -g0;
+    } 
+  }
+
+  void modifyIMatrix(Eigen::MatrixXd &i, Eigen::MatrixXd &v, int MAX_NODE_ID,
+                     double t, double deltaT) override {
+    this->deltaT = deltaT;
+    if (PIN_1 != -1) {
+      // ideq large DC signal current
+      // issd small signal current
+      i(PIN_1) += -getInnerISource(deltaT);
+    }
+
+    if (PIN_2 != -1) {
+      // ideq large DC signal current
+      // issd small signal current
+      i(PIN_2) += getInnerISource(deltaT);
+    }
+  }
+
+public:
+  double getInnerISource(double deltaT) { return previousV / getInnerResistance(deltaT); }
+
+  double getInnerResistance(double deltaT) { return deltaT / C; }
+};

--- a/src/Elements/CapacitorElement.h
+++ b/src/Elements/CapacitorElement.h
@@ -7,13 +7,11 @@ class CapacitorElement : public CircuitElement {
 private:
   double previousV = 0;
   double C;
-  double deltaT;
   int PIN_1, PIN_2;
 
 public:
   int getPIN1() { return PIN_1; }
   int getPIN2() { return PIN_2; }
-  double getDeltaT() { return deltaT; }
 
 public:
   static std::unique_ptr<CapacitorElement> create(double C, double initialV,
@@ -35,7 +33,6 @@ public:
 
   void modifyGMatrix(Eigen::MatrixXd &g, Eigen::MatrixXd &v, int MAX_NODE_ID,
                      double t, double deltaT) override {
-    this->deltaT = deltaT;
     double g0 = 1.0 / getInnerResistance(deltaT);
     if (PIN_1 != -1)
       g(PIN_1, PIN_1) += g0;
@@ -49,7 +46,6 @@ public:
 
   void modifyIMatrix(Eigen::MatrixXd &i, Eigen::MatrixXd &v, int MAX_NODE_ID,
                      double t, double deltaT) override {
-    this->deltaT = deltaT;
     if (PIN_1 != -1) {
       // ideq large DC signal current
       // issd small signal current

--- a/src/Elements/CurrentSourceElement.h
+++ b/src/Elements/CurrentSourceElement.h
@@ -1,0 +1,48 @@
+#pragma once
+#include "Circuit.h"
+#include <CircuitElement.h>
+#include <memory>
+
+class CurrentSourceElement : public CircuitElement {
+public:
+  CurrentSourceElement() : CircuitElement() {};
+  ~CurrentSourceElement() {};
+  static std::unique_ptr<CurrentSourceElement> create(double i, int pin1,
+                                                      int pin2) {
+    // current flow from pin1 to pin2, + at pin1 - at pin2
+    std::unique_ptr<CurrentSourceElement> vsrc =
+        std::make_unique<CurrentSourceElement>();
+    vsrc->i = i;
+    vsrc->pin1 = pin1;
+    vsrc->pin2 = pin2;
+    return std::move(vsrc);
+  }
+
+  int getVoltageSourceCount() override { return 0; }
+
+  void modifyGMatrix(Eigen::MatrixXd &g, Eigen::MatrixXd &v, int MAX_NODE_ID,
+                     double t, double deltaT) override {}
+
+  void modifyIMatrix(Eigen::MatrixXd &i, Eigen::MatrixXd &v, int MAX_NODE_ID,
+                     double t, double deltaT) override {
+    if (pin1 != -1) {
+      i(pin1) += this->i;
+    }
+
+    if (pin2 != -1) {
+      i(pin2) += -this->i;
+    }
+  }
+
+  void incTime(Circuit *circuit) override {}
+
+private:
+  double i;
+  int pin1;
+  int pin2;
+
+public:
+  int getPin1() { return pin1; }
+
+  int getPin2() { return pin2; }
+};

--- a/src/Elements/DiodeElement.h
+++ b/src/Elements/DiodeElement.h
@@ -1,0 +1,137 @@
+#pragma once
+#include "CircuitElement.h"
+#include <Circuit.h>
+#include <cmath>
+#include <memory>
+
+class DiodeElement : public CircuitElement {
+private:
+  double Is;
+  double Vt;
+  int PIN_1, PIN_2, PIN_M;
+  int voltageSourceID;
+
+public:
+  int getVoltageSourceID() { return voltageSourceID; }
+
+public:
+  int getPIN1() { return PIN_1; }
+  int getPIN2() { return PIN_2; }
+
+public:
+  static std::unique_ptr<DiodeElement> create(double Is, double Vt, int PIN_1,
+                                              int PIN_2, int PIN_M,
+                                              int voltageSouceID) {
+    std::unique_ptr<DiodeElement> cap = std::make_unique<DiodeElement>(
+        Is, Vt, PIN_1, PIN_2, PIN_M, voltageSouceID);
+    return std::move(cap);
+  }
+
+  DiodeElement(double Is, double Vt, int PIN_1, int PIN_2, int PIN_M,
+               int voltageSourceID) {
+    this->Is = Is;
+    this->Vt = Vt;
+    this->PIN_1 = PIN_1;
+    this->PIN_2 = PIN_2;
+    this->PIN_M = PIN_M;
+    this->voltageSourceID = voltageSourceID;
+  }
+
+public:
+  int getVoltageSourceCount() override { return 1; }
+
+  void modifyGMatrix(Eigen::MatrixXd &g, Eigen::MatrixXd &v, int MAX_NODE_ID,
+                     double t, double deltaT) override {
+    double v1, v2;
+    if (PIN_1 == -1) {
+      v1 = 0;
+    } else {
+      v1 = v(PIN_1);
+    }
+
+    if (PIN_2 == -1) {
+      v2 = 0;
+    } else {
+      v2 = v(PIN_2);
+    }
+    double lastIterateV = v1 - v2;
+
+    double g0 = getInnerConductance(deltaT, Is, Vt, v1 - v2);
+    if (PIN_1 != -1)
+      g(PIN_1, PIN_1) += g0;
+    if (PIN_2 != -1)
+      g(PIN_2, PIN_2) += g0;
+    if (PIN_1 != -1 && PIN_2 != -1) {
+      g(PIN_1, PIN_2) += -g0;
+      g(PIN_2, PIN_1) += -g0;
+    }
+
+    if (PIN_2 != -1) {
+      g(MAX_NODE_ID + 1 + voltageSourceID, PIN_2) = 1;
+      // std::cout << "success1" << std::endl;
+      g(PIN_2, MAX_NODE_ID + 1 + voltageSourceID) = 1;
+      // std::cout << "success2" << std::endl;
+    }
+
+    if (PIN_M != -1) {
+      g(MAX_NODE_ID + 1 + voltageSourceID, PIN_M) = -1;
+      g(PIN_M, MAX_NODE_ID + 1 + voltageSourceID) = -1;
+    }
+
+    double GMIN = pow(10, -9);
+    // add gmin
+    if (PIN_1 != -1 && PIN_2 != -1) {
+      g(PIN_1, PIN_2) += -GMIN;
+      g(PIN_2, PIN_1) += -GMIN;
+    }
+
+    if (PIN_1 != -1) {
+      g(PIN_1, PIN_1) += GMIN;
+    }
+
+    if (PIN_2 != -1) {
+      g(PIN_2, PIN_2) += GMIN;
+    }
+  }
+
+  void modifyIMatrix(Eigen::MatrixXd &i, Eigen::MatrixXd &v, int MAX_NODE_ID,
+                     double t, double deltaT) override {
+
+    double v1, v2;
+    if (PIN_1 == -1) {
+      v1 = 0;
+    } else {
+      v1 = v(PIN_1);
+    }
+
+    if (PIN_2 == -1) {
+      v2 = 0;
+    } else {
+      v2 = v(PIN_2);
+    }
+
+    double lastIterateV = v1 - v2;
+    if (PIN_1 != -1) {
+      i(PIN_1) += -getInnerISource(deltaT, Is, Vt, lastIterateV);
+    }
+
+    if (PIN_2 != -1) {
+      i(PIN_2) += getInnerISource(deltaT, Is, Vt, lastIterateV);
+    }
+
+    i(MAX_NODE_ID + 1 + voltageSourceID) = 0;
+  }
+
+  void incTime(Circuit *circuit) override {}
+
+public:
+  static double getInnerISource(double deltaT, double Is, double Vt,
+                                double lastIterateV) {
+    return Is * (exp(lastIterateV / Vt) - 1) -
+           getInnerConductance(deltaT, Is, Vt, lastIterateV) * lastIterateV;
+  }
+  static double getInnerConductance(double deltaT, double Is, double Vt,
+                                    double lastIterateV) {
+    return Is * (exp(lastIterateV / Vt) - 1) / Vt;
+  }
+};

--- a/src/Elements/InductorElement.h
+++ b/src/Elements/InductorElement.h
@@ -8,29 +8,38 @@ private:
   double previousI = 0;
   double previousV = 0;
   double L;
-  int PIN_1, PIN_2;
+  int PIN_1, PIN_2, PIN_M;
+  int voltageSourceID;
+public:
+  int getVoltageSourceID() {
+    return voltageSourceID;
+  }
+
 public:
   int getPIN1() { return PIN_1; }
   int getPIN2() { return PIN_2; }
 
 public:
-  static std::unique_ptr<InductorElement> create(double L, double initialI,
-                                                  int PIN_1, int PIN_2) {
+  static std::unique_ptr<InductorElement>
+  create(double L, double initialI, int PIN_1, int PIN_2, int PIN_M, int voltageSouceID) {
     std::unique_ptr<InductorElement> cap =
-        std::make_unique<InductorElement>(L, initialI, PIN_1, PIN_2);
+        std::make_unique<InductorElement>(L, initialI, PIN_1, PIN_2, PIN_M, voltageSouceID);
     return std::move(cap);
   }
 
-  InductorElement(double L, double initialI, int PIN_1, int PIN_2) {
+  InductorElement(double L, double initialI, int PIN_1, int PIN_2, int PIN_M, int voltageSourceID) {
     this->L = L;
     previousI = initialI;
     this->PIN_1 = PIN_1;
     this->PIN_2 = PIN_2;
+    this->PIN_M = PIN_M;
+    this->voltageSourceID = voltageSourceID;
   }
 
 public:
-  // FIXME: Add a 0 volt votlage source to the end so that the current can be got by UIElement
-  int getVoltageSourceCount() override { return 0; }
+  // FIXME: Add a 0 volt votlage source to the end so that the current can be
+  // got by UIElement
+  int getVoltageSourceCount() override { return 1; }
 
   void modifyGMatrix(Eigen::MatrixXd &g, Eigen::MatrixXd &v, int MAX_NODE_ID,
                      double t, double deltaT) override {
@@ -42,6 +51,18 @@ public:
     if (PIN_1 != -1 && PIN_2 != -1) {
       g(PIN_1, PIN_2) += -g0;
       g(PIN_2, PIN_1) += -g0;
+    }
+
+    if (PIN_2 != -1) {
+      g(MAX_NODE_ID + 1 + voltageSourceID, PIN_2) = 1;
+      // std::cout << "success1" << std::endl;
+      g(PIN_2, MAX_NODE_ID + 1 + voltageSourceID) = 1;
+      // std::cout << "success2" << std::endl;
+    }
+
+    if (PIN_M != -1) {
+      g(MAX_NODE_ID + 1 + voltageSourceID, PIN_M) = -1;
+      g(PIN_M, MAX_NODE_ID + 1 + voltageSourceID) = -1;
     }
   }
 
@@ -55,7 +76,9 @@ public:
     if (PIN_2 != -1) {
       i(PIN_2) += getInnerISource(deltaT, previousI, previousV, L);
     }
-    
+
+
+    i(MAX_NODE_ID + 1 + voltageSourceID) = 0;
   }
 
   void incTime(Circuit *circuit) override {
@@ -74,18 +97,26 @@ public:
     // std::cout << "L: " << L << std::endl;
     circuit->setCircuitID(Circuit::circuitCounter);
     Circuit::circuitCounter++;
-    double RI = (pin1Volt - pin2Volt) * getInnerConductance(circuit->getDeltaT(), previousI, previousV, L);
-    previousI = RI + getInnerISource(circuit->getDeltaT(), previousI, previousV, L);    
+    double RI =
+        (pin1Volt - pin2Volt) *
+        getInnerConductance(circuit->getDeltaT(), previousI, previousV, L);
+    previousI =
+        RI + getInnerISource(circuit->getDeltaT(), previousI, previousV, L);
     previousV = pin1Volt - pin2Volt;
     // std::cout << "PreviousI: " << previousI << std::endl;
     //
-    // std::cout << "CID:" << circuit->getCircuitID() << "updatedP:" << previousV
-              // << std::endl;
+    // std::cout << "CID:" << circuit->getCircuitID() << "updatedP:" <<
+    // previousV
+    // << std::endl;
   }
 
 public:
-  static double getInnerISource(double deltaT, double previousI, double previousV, double L) {
-    return previousI + deltaT / (2*L) * previousV;
+  static double getInnerISource(double deltaT, double previousI,
+                                double previousV, double L) {
+    return previousI + deltaT / (2 * L) * previousV;
   }
-  static double getInnerConductance(double deltaT, double previousI, double previousV, double L) { return deltaT / (2*L); }
+  static double getInnerConductance(double deltaT, double previousI,
+                                    double previousV, double L) {
+    return deltaT / (2 * L);
+  }
 };

--- a/src/Elements/InductorElement.h
+++ b/src/Elements/InductorElement.h
@@ -7,81 +7,83 @@ class InductorElement : public CircuitElement {
 private:
   double previousI = 0;
   double L;
-  int PIN_1, PIN_2, PIN_M;
-  int voltageSourceID;
-public:
-  int getVoltageSourceID() {
-    return voltageSourceID;
-  }
+  int PIN_1, PIN_2;
 public:
   int getPIN1() { return PIN_1; }
   int getPIN2() { return PIN_2; }
-  int getPINM() { return PIN_M; }
 
 public:
   static std::unique_ptr<InductorElement> create(double L, double initialI,
-                                                  int PIN_1, int PIN_2, int PIN_M, int voltageSourceID) {
+                                                  int PIN_1, int PIN_2) {
     std::unique_ptr<InductorElement> cap =
-        std::make_unique<InductorElement>(L, initialI, PIN_1, PIN_2, PIN_M, voltageSourceID);
+        std::make_unique<InductorElement>(L, initialI, PIN_1, PIN_2);
     return std::move(cap);
   }
 
-  InductorElement(double L, double initialI, int PIN_1, int PIN_2, int PIN_M, int voltageSourceID) {
+  InductorElement(double L, double initialI, int PIN_1, int PIN_2) {
     this->L = L;
     previousI = initialI;
     this->PIN_1 = PIN_1;
     this->PIN_2 = PIN_2;
-    this->PIN_M = PIN_M;
-    this->voltageSourceID = voltageSourceID;
   }
 
 public:
-  int getVoltageSourceCount() override { return 1; }
+  // FIXME: Add a 0 volt votlage source to the end so that the current can be got by UIElement
+  int getVoltageSourceCount() override { return 0; }
 
   void modifyGMatrix(Eigen::MatrixXd &g, Eigen::MatrixXd &v, int MAX_NODE_ID,
                      double t, double deltaT) override {
-    double g0 = 1.0 / getInnerResistance(deltaT, previousI, L);
+    double g0 = getInnerConductance(deltaT, previousI, L);
     if (PIN_1 != -1)
       g(PIN_1, PIN_1) += g0;
-    if (PIN_M != -1)
-      g(PIN_M, PIN_M) += g0;
-    if (PIN_1 != -1 && PIN_M != -1) {
-      g(PIN_1, PIN_M) += -g0;
-      g(PIN_M, PIN_1) += -g0;
-    }
-
-    if (PIN_M != -1) {
-      g(MAX_NODE_ID + 1 + voltageSourceID, PIN_M) = 1;
-      // std::cout << "success1" << std::endl;
-      g(PIN_M, MAX_NODE_ID + 1 + voltageSourceID) = 1;
-      // std::cout << "success2" << std::endl;
-    }
-
-    if (PIN_2 != -1) {
-      g(MAX_NODE_ID + 1 + voltageSourceID, PIN_2) = -1;
-      g(PIN_2, MAX_NODE_ID + 1 + voltageSourceID) = -1;
+    if (PIN_2 != -1)
+      g(PIN_2, PIN_2) += g0;
+    if (PIN_1 != -1 && PIN_2 != -1) {
+      g(PIN_1, PIN_2) += -g0;
+      g(PIN_2, PIN_1) += -g0;
     }
   }
 
   void modifyIMatrix(Eigen::MatrixXd &i, Eigen::MatrixXd &v, int MAX_NODE_ID,
                      double t, double deltaT) override {
-    i(MAX_NODE_ID + 1 + voltageSourceID) = getInnerVSource(deltaT, previousI, L);
+
+    if (PIN_1 != -1) {
+      i(PIN_1) += -getInnerISource(deltaT, previousI, L);
+    }
+
+    if (PIN_2 != -1) {
+      i(PIN_2) += getInnerISource(deltaT, previousI, L);
+    }
     
   }
 
   void incTime(Circuit *circuit) override {
+    double pin1Volt = 0;
+    double pin2Volt = 0;
+    if (PIN_1 != -1) {
+      pin1Volt = *circuit->getVoltagePointer(PIN_1);
+    }
+
+    if (PIN_2 != -1) {
+      pin2Volt = *circuit->getVoltagePointer(PIN_2);
+    }
+    std::cout << "Pin1Volt: " << pin1Volt << std::endl;
+    std::cout << "Pin2Volt: " << pin2Volt << std::endl;
+    std::cout << "DeltaT: " << circuit->getDeltaT() << std::endl;
+    std::cout << "L: " << L << std::endl;
     circuit->setCircuitID(Circuit::circuitCounter);
     Circuit::circuitCounter++;
-    previousI = *circuit->getVoltagePointer(circuit->getMaxNodeID() +
-              voltageSourceID + 1);
+    double RI = (pin1Volt - pin2Volt) * getInnerConductance(circuit->getDeltaT(), previousI, L);
+    previousI = RI + getInnerISource(circuit->getDeltaT(), previousI, L);    
     std::cout << "PreviousI: " << previousI << std::endl;
+    //
     // std::cout << "CID:" << circuit->getCircuitID() << "updatedP:" << previousV
               // << std::endl;
   }
 
 public:
-  static double getInnerVSource(double deltaT, double previousI, double L) {
-    return -previousI * InductorElement::getInnerResistance(deltaT, previousI, L);
+  static double getInnerISource(double deltaT, double previousI, double L) {
+    return previousI;
   }
-  static double getInnerResistance(double deltaT, double previousI, double L) { return L / deltaT; }
+  static double getInnerConductance(double deltaT, double previousI, double L) { return deltaT / L; }
 };

--- a/src/Elements/InductorElement.h
+++ b/src/Elements/InductorElement.h
@@ -1,0 +1,87 @@
+#pragma once
+#include "CircuitElement.h"
+#include <Circuit.h>
+#include <memory>
+
+class InductorElement : public CircuitElement {
+private:
+  double previousI = 0;
+  double L;
+  int PIN_1, PIN_2, PIN_M;
+  int voltageSourceID;
+public:
+  int getVoltageSourceID() {
+    return voltageSourceID;
+  }
+public:
+  int getPIN1() { return PIN_1; }
+  int getPIN2() { return PIN_2; }
+  int getPINM() { return PIN_M; }
+
+public:
+  static std::unique_ptr<InductorElement> create(double L, double initialI,
+                                                  int PIN_1, int PIN_2, int PIN_M, int voltageSourceID) {
+    std::unique_ptr<InductorElement> cap =
+        std::make_unique<InductorElement>(L, initialI, PIN_1, PIN_2, PIN_M, voltageSourceID);
+    return std::move(cap);
+  }
+
+  InductorElement(double L, double initialI, int PIN_1, int PIN_2, int PIN_M, int voltageSourceID) {
+    this->L = L;
+    previousI = initialI;
+    this->PIN_1 = PIN_1;
+    this->PIN_2 = PIN_2;
+    this->PIN_M = PIN_M;
+    this->voltageSourceID = voltageSourceID;
+  }
+
+public:
+  int getVoltageSourceCount() override { return 1; }
+
+  void modifyGMatrix(Eigen::MatrixXd &g, Eigen::MatrixXd &v, int MAX_NODE_ID,
+                     double t, double deltaT) override {
+    double g0 = 1.0 / getInnerResistance(deltaT, previousI, L);
+    if (PIN_1 != -1)
+      g(PIN_1, PIN_1) += g0;
+    if (PIN_M != -1)
+      g(PIN_M, PIN_M) += g0;
+    if (PIN_1 != -1 && PIN_M != -1) {
+      g(PIN_1, PIN_M) += -g0;
+      g(PIN_M, PIN_1) += -g0;
+    }
+
+    if (PIN_M != -1) {
+      g(MAX_NODE_ID + 1 + voltageSourceID, PIN_M) = 1;
+      // std::cout << "success1" << std::endl;
+      g(PIN_M, MAX_NODE_ID + 1 + voltageSourceID) = 1;
+      // std::cout << "success2" << std::endl;
+    }
+
+    if (PIN_2 != -1) {
+      g(MAX_NODE_ID + 1 + voltageSourceID, PIN_2) = -1;
+      g(PIN_2, MAX_NODE_ID + 1 + voltageSourceID) = -1;
+    }
+  }
+
+  void modifyIMatrix(Eigen::MatrixXd &i, Eigen::MatrixXd &v, int MAX_NODE_ID,
+                     double t, double deltaT) override {
+    i(MAX_NODE_ID + 1 + voltageSourceID) = getInnerVSource(deltaT, previousI, L);
+    
+  }
+
+  void incTime(Circuit *circuit) override {
+    circuit->setCircuitID(Circuit::circuitCounter);
+    Circuit::circuitCounter++;
+    previousI = *circuit->getVoltagePointer(circuit->getMaxNodeID() +
+              voltageSourceID + 1);
+    std::cout << "PreviousI: " << previousI << std::endl;
+    // std::cout << "CID:" << circuit->getCircuitID() << "updatedP:" << previousV
+              // << std::endl;
+  }
+
+public:
+  static double getInnerVSource(double deltaT, double previousI, double L) {
+    return -previousI * InductorElement::getInnerResistance(deltaT, previousI, L);
+  }
+  static double getInnerResistance(double deltaT, double previousI, double L) { return L / deltaT; }
+};

--- a/src/Elements/InductorElement.h
+++ b/src/Elements/InductorElement.h
@@ -6,6 +6,7 @@
 class InductorElement : public CircuitElement {
 private:
   double previousI = 0;
+  double previousV = 0;
   double L;
   int PIN_1, PIN_2;
 public:
@@ -33,7 +34,7 @@ public:
 
   void modifyGMatrix(Eigen::MatrixXd &g, Eigen::MatrixXd &v, int MAX_NODE_ID,
                      double t, double deltaT) override {
-    double g0 = getInnerConductance(deltaT, previousI, L);
+    double g0 = getInnerConductance(deltaT, previousI, previousV, L);
     if (PIN_1 != -1)
       g(PIN_1, PIN_1) += g0;
     if (PIN_2 != -1)
@@ -48,11 +49,11 @@ public:
                      double t, double deltaT) override {
 
     if (PIN_1 != -1) {
-      i(PIN_1) += -getInnerISource(deltaT, previousI, L);
+      i(PIN_1) += -getInnerISource(deltaT, previousI, previousV, L);
     }
 
     if (PIN_2 != -1) {
-      i(PIN_2) += getInnerISource(deltaT, previousI, L);
+      i(PIN_2) += getInnerISource(deltaT, previousI, previousV, L);
     }
     
   }
@@ -67,23 +68,24 @@ public:
     if (PIN_2 != -1) {
       pin2Volt = *circuit->getVoltagePointer(PIN_2);
     }
-    std::cout << "Pin1Volt: " << pin1Volt << std::endl;
-    std::cout << "Pin2Volt: " << pin2Volt << std::endl;
-    std::cout << "DeltaT: " << circuit->getDeltaT() << std::endl;
-    std::cout << "L: " << L << std::endl;
+    // std::cout << "Pin1Volt: " << pin1Volt << std::endl;
+    // std::cout << "Pin2Volt: " << pin2Volt << std::endl;
+    // std::cout << "DeltaT: " << circuit->getDeltaT() << std::endl;
+    // std::cout << "L: " << L << std::endl;
     circuit->setCircuitID(Circuit::circuitCounter);
     Circuit::circuitCounter++;
-    double RI = (pin1Volt - pin2Volt) * getInnerConductance(circuit->getDeltaT(), previousI, L);
-    previousI = RI + getInnerISource(circuit->getDeltaT(), previousI, L);    
-    std::cout << "PreviousI: " << previousI << std::endl;
+    double RI = (pin1Volt - pin2Volt) * getInnerConductance(circuit->getDeltaT(), previousI, previousV, L);
+    previousI = RI + getInnerISource(circuit->getDeltaT(), previousI, previousV, L);    
+    previousV = pin1Volt - pin2Volt;
+    // std::cout << "PreviousI: " << previousI << std::endl;
     //
     // std::cout << "CID:" << circuit->getCircuitID() << "updatedP:" << previousV
               // << std::endl;
   }
 
 public:
-  static double getInnerISource(double deltaT, double previousI, double L) {
-    return previousI;
+  static double getInnerISource(double deltaT, double previousI, double previousV, double L) {
+    return previousI + deltaT / (2*L) * previousV;
   }
-  static double getInnerConductance(double deltaT, double previousI, double L) { return deltaT / L; }
+  static double getInnerConductance(double deltaT, double previousI, double previousV, double L) { return deltaT / (2*L); }
 };

--- a/src/Elements/InductorElement.h
+++ b/src/Elements/InductorElement.h
@@ -37,8 +37,6 @@ public:
   }
 
 public:
-  // FIXME: Add a 0 volt votlage source to the end so that the current can be
-  // got by UIElement
   int getVoltageSourceCount() override { return 1; }
 
   void modifyGMatrix(Eigen::MatrixXd &g, Eigen::MatrixXd &v, int MAX_NODE_ID,

--- a/src/Elements/NMOSElement.h
+++ b/src/Elements/NMOSElement.h
@@ -80,7 +80,7 @@ public:
       g(PIN_S, PIN_D) += -g0;
     }
 
-    double GMIN = pow(10, -6);
+    double GMIN = pow(10, -9);
     // add gmin
     if (PIN_G != -1 && PIN_S != -1) {
       g(PIN_G, PIN_S) += -GMIN;

--- a/src/Elements/NMOSElement.h
+++ b/src/Elements/NMOSElement.h
@@ -80,27 +80,28 @@ public:
       g(PIN_S, PIN_D) += -g0;
     }
 
+    double GMIN = pow(10, -6);
     // add gmin
     if (PIN_G != -1 && PIN_S != -1) {
-      g(PIN_G, PIN_S) += -pow(10, -12);
-      g(PIN_S, PIN_G) += -pow(10, -12);
+      g(PIN_G, PIN_S) += -GMIN;
+      g(PIN_S, PIN_G) += -GMIN;
     }
 
     if (PIN_G != -1 && PIN_D != -1) {
-      g(PIN_G, PIN_D) += -pow(10, -12);
-      g(PIN_G, PIN_D) += -pow(10, -12);
+      g(PIN_G, PIN_D) += -GMIN;
+      g(PIN_G, PIN_D) += -GMIN;
     }
 
     if (PIN_G != -1) {
-      g(PIN_G, PIN_G) += 2*pow(10, -12);
+      g(PIN_G, PIN_G) += 2*GMIN;
     }
 
     if (PIN_D != -1) {
-      g(PIN_D, PIN_D) += pow(10, -12);
+      g(PIN_D, PIN_D) += GMIN;
     }
 
     if (PIN_S != -1) {
-      g(PIN_S, PIN_S) += pow(10, -12);
+      g(PIN_S, PIN_S) += GMIN;
     }
   }
 

--- a/src/Elements/NMOSElement.h
+++ b/src/Elements/NMOSElement.h
@@ -144,6 +144,10 @@ public:
     }
   }
 
+  void incTime(Circuit *circuit) override {
+    
+  }
+
 private:
   int PIN_G;
   int PIN_D;

--- a/src/Elements/NMOSElement.h
+++ b/src/Elements/NMOSElement.h
@@ -46,7 +46,7 @@ public:
   }
 
   void modifyGMatrix(Eigen::MatrixXd &g, Eigen::MatrixXd &v, int MAX_NODE_ID,
-                     double t) override {
+                     double t, double deltaT) override {
     // g0
     double vg, vd, vs;
     if (PIN_G == -1) {
@@ -105,7 +105,7 @@ public:
   }
 
   void modifyIMatrix(Eigen::MatrixXd &i, Eigen::MatrixXd &v, int MAX_NODE_ID,
-                     double t) override {
+                     double t, double deltaT) override {
     double vg, vd, vs;
     if (PIN_G == -1) {
       vg = 0;

--- a/src/Elements/PMOSElement.h
+++ b/src/Elements/PMOSElement.h
@@ -42,7 +42,7 @@ public:
     } else {
       vs = vResult(PIN_S);
     }
-    return calid(K, vg - vs, vd - vs, VT, VA);
+    return calid(K, vs - vg, vs - vd, VT, VA);
   }
 
   void modifyGMatrix(Eigen::MatrixXd &g, Eigen::MatrixXd &v, int MAX_NODE_ID,
@@ -67,7 +67,7 @@ public:
       vs = v(PIN_S);
     }
 
-    double g0 = calg0(K, vg - vs, vd - vs, VT, VA);
+    double g0 = calg0(K, vs - vg, vs - vd, VT, VA);
 
     if (PIN_D != -1)
       g(PIN_D, PIN_D) += g0;
@@ -80,7 +80,7 @@ public:
       g(PIN_S, PIN_D) += -g0;
     }
 
-    double GMIN = pow(10, -6);
+    double GMIN = pow(10, -9);
     // add gmin
     if (PIN_G != -1 && PIN_S != -1) {
       g(PIN_G, PIN_S) += -GMIN;
@@ -126,21 +126,21 @@ public:
       vs = v(PIN_S);
     }
 
-    double ideq = calideq(K, vg - vs, vd - vs, VT, VA);
-    double issd = calissd(K, vg - vs, vd - vs, VT, VA);
+    double ideq = calideq(K, vs - vg, vs - vd, VT, VA);
+    double issd = calissd(K, vs - vg, vs - vd, VT, VA);
 
     if (PIN_D != -1) {
       // ideq large DC signal current
       // issd small signal current
-      i(PIN_D) += -ideq;
-      i(PIN_D) += -issd;
+      i(PIN_D) += ideq;
+      i(PIN_D) += issd;
     }
 
     if (PIN_S != -1) {
       // ideq large DC signal current
       // issd small signal current
-      i(PIN_S) += ideq;
-      i(PIN_S) += issd;
+      i(PIN_S) += -ideq;
+      i(PIN_S) += -issd;
     }
   }
 
@@ -164,36 +164,36 @@ public:
   int getPIN_S() { return PIN_S; }
 
 private:
-  double calg0(double k, double vgs, double vds, double vt, double va) {
-    if (vgs - vt < 0)
+  double calg0(double k, double vsg, double vsd, double vt, double va) {
+    if (vsg - vt < 0)
       return 0;
-    if (vds <= vgs - vt)
-      return k * ((vgs - vt) - vds);
-    return ((k / 2) * pow(vgs - vt, 2)) / va;
+    if (-vsd <= -vsg - vt)
+      return k * ((vsg - vt) - vsd);
+    return calid(k, vsg, vsd, vt, va)/va;
   }
 
-  double calgm(double k, double vgs, double vds, double vt, double va) {
-    if (vgs - vt < 0)
+  double calgm(double k, double vsg, double vsd, double vt, double va) {
+    if (vsg - vt < 0)
       return 0;
-    if (vds <= vgs - vt)
-      return k * vds;
-    return k * (vgs - vt) * (1 + (vds - (vgs - vt)) / va);
+    if (-vsd <= -vsg - vt)
+      return k * vsd;
+    return pow(2*k*calid(k, vsg, vsd, vt, va), 1/2.0);
   }
 
-  double calid(double k, double vgs, double vds, double vt, double va) {
-    if (vgs - vt < 0)
+  double calid(double k, double vsg, double vsd, double vt, double va) {
+    if (vsg - vt < 0)
       return 0;
-    if (vds <= vgs - vt)
-      return k * ((vgs - vt) - vds / 2) * vds;
-    return (k / 2) * pow(vgs - vt, 2) * (1 + (vds - (vgs - vt)) / va);
+    if (-vsd <= -vsg - vt)
+      return k * ((vsg - vt) - vsd / 2) * vsd;
+    return (k / 2) * pow(vsg - vt, 2) * (1 + (vsd - (vsd - vt)) / va);
   }
 
-  double calissd(double k, double vgs, double vds, double vt, double va) {
-    return calgm(k, vgs, vds, vt, va) * vgs;
+  double calissd(double k, double vsg, double vsd, double vt, double va) {
+    return calgm(k, vsg, vsd, vt, va) * vsg;
   }
 
-  double calideq(double k, double vgs, double vds, double vt, double va) {
-    return calid(k, vgs, vds, vt, va) - calissd(k, vgs, vds, vt, va) -
-           calg0(k, vgs, vds, vt, va) * vds;
+  double calideq(double k, double vsg, double vsd, double vt, double va) {
+    return calid(k, vsg, vsd, vt, va) - calissd(k, vsg, vsd, vt, va) -
+           calg0(k, vsg, vsd, vt, va) * vsd;
   }
 };

--- a/src/Elements/PMOSElement.h
+++ b/src/Elements/PMOSElement.h
@@ -1,0 +1,199 @@
+#pragma once
+#include "CircuitElement.h"
+#include <memory>
+
+class PMOSElement : public CircuitElement {
+private:
+  double id;
+
+public:
+  PMOSElement() : CircuitElement() {}
+  ~PMOSElement() {}
+  static std::unique_ptr<PMOSElement> create(double K, double VA, double VT,
+                                             int PIN_G, int PIN_D, int PIN_S) {
+    std::unique_ptr<PMOSElement> pmosEle = std::make_unique<PMOSElement>();
+    pmosEle->PIN_G = PIN_G;
+    pmosEle->PIN_D = PIN_D;
+    pmosEle->PIN_S = PIN_S;
+    pmosEle->K = K;
+    pmosEle->VA = VA;
+    pmosEle->VT = VT;
+    return std::move(pmosEle);
+  }
+
+  int getVoltageSourceCount() override { return 0; }
+
+  double getId(Eigen::MatrixXd &vResult) {
+    double vg, vd, vs;
+    if (PIN_G == -1) {
+      vg = 0;
+    } else {
+      vg = vResult(PIN_G);
+    }
+
+    if (PIN_D == -1) {
+      vd = 0;
+    } else {
+      vd = vResult(PIN_D);
+    }
+
+    if (PIN_S == -1) {
+      vs = 0;
+    } else {
+      vs = vResult(PIN_S);
+    }
+    return calid(K, vg - vs, vd - vs, VT, VA);
+  }
+
+  void modifyGMatrix(Eigen::MatrixXd &g, Eigen::MatrixXd &v, int MAX_NODE_ID,
+                     double t, double deltaT) override {
+    // g0
+    double vg, vd, vs;
+    if (PIN_G == -1) {
+      vg = 0;
+    } else {
+      vg = v(PIN_G);
+    }
+
+    if (PIN_D == -1) {
+      vd = 0;
+    } else {
+      vd = v(PIN_D);
+    }
+
+    if (PIN_S == -1) {
+      vs = 0;
+    } else {
+      vs = v(PIN_S);
+    }
+
+    double g0 = calg0(K, vg - vs, vd - vs, VT, VA);
+
+    if (PIN_D != -1)
+      g(PIN_D, PIN_D) += g0;
+
+    if (PIN_S != -1)
+      g(PIN_S, PIN_S) += g0;
+
+    if (PIN_D != -1 && PIN_S != -1) {
+      g(PIN_D, PIN_S) += -g0;
+      g(PIN_S, PIN_D) += -g0;
+    }
+
+    double GMIN = pow(10, -6);
+    // add gmin
+    if (PIN_G != -1 && PIN_S != -1) {
+      g(PIN_G, PIN_S) += -GMIN;
+      g(PIN_S, PIN_G) += -GMIN;
+    }
+
+    if (PIN_G != -1 && PIN_D != -1) {
+      g(PIN_G, PIN_D) += -GMIN;
+      g(PIN_G, PIN_D) += -GMIN;
+    }
+
+    if (PIN_G != -1) {
+      g(PIN_G, PIN_G) += 2*GMIN;
+    }
+
+    if (PIN_D != -1) {
+      g(PIN_D, PIN_D) += GMIN;
+    }
+
+    if (PIN_S != -1) {
+      g(PIN_S, PIN_S) += GMIN;
+    }
+  }
+
+  void modifyIMatrix(Eigen::MatrixXd &i, Eigen::MatrixXd &v, int MAX_NODE_ID,
+                     double t, double deltaT) override {
+    double vg, vd, vs;
+    if (PIN_G == -1) {
+      vg = 0;
+    } else {
+      vg = v(PIN_G);
+    }
+
+    if (PIN_D == -1) {
+      vd = 0;
+    } else {
+      vd = v(PIN_D);
+    }
+
+    if (PIN_S == -1) {
+      vs = 0;
+    } else {
+      vs = v(PIN_S);
+    }
+
+    double ideq = calideq(K, vg - vs, vd - vs, VT, VA);
+    double issd = calissd(K, vg - vs, vd - vs, VT, VA);
+
+    if (PIN_D != -1) {
+      // ideq large DC signal current
+      // issd small signal current
+      i(PIN_D) += -ideq;
+      i(PIN_D) += -issd;
+    }
+
+    if (PIN_S != -1) {
+      // ideq large DC signal current
+      // issd small signal current
+      i(PIN_S) += ideq;
+      i(PIN_S) += issd;
+    }
+  }
+
+  void incTime(Circuit *circuit) override {
+    
+  }
+
+private:
+  int PIN_G;
+  int PIN_D;
+  int PIN_S;
+  double K;
+  double VA;
+  double VT;
+
+public:
+  int getPIN_G() { return PIN_G; }
+
+  int getPIN_D() { return PIN_D; }
+
+  int getPIN_S() { return PIN_S; }
+
+private:
+  double calg0(double k, double vgs, double vds, double vt, double va) {
+    if (vgs - vt < 0)
+      return 0;
+    if (vds <= vgs - vt)
+      return k * ((vgs - vt) - vds);
+    return ((k / 2) * pow(vgs - vt, 2)) / va;
+  }
+
+  double calgm(double k, double vgs, double vds, double vt, double va) {
+    if (vgs - vt < 0)
+      return 0;
+    if (vds <= vgs - vt)
+      return k * vds;
+    return k * (vgs - vt) * (1 + (vds - (vgs - vt)) / va);
+  }
+
+  double calid(double k, double vgs, double vds, double vt, double va) {
+    if (vgs - vt < 0)
+      return 0;
+    if (vds <= vgs - vt)
+      return k * ((vgs - vt) - vds / 2) * vds;
+    return (k / 2) * pow(vgs - vt, 2) * (1 + (vds - (vgs - vt)) / va);
+  }
+
+  double calissd(double k, double vgs, double vds, double vt, double va) {
+    return calgm(k, vgs, vds, vt, va) * vgs;
+  }
+
+  double calideq(double k, double vgs, double vds, double vt, double va) {
+    return calid(k, vgs, vds, vt, va) - calissd(k, vgs, vds, vt, va) -
+           calg0(k, vgs, vds, vt, va) * vds;
+  }
+};

--- a/src/Elements/ResistorElement.h
+++ b/src/Elements/ResistorElement.h
@@ -33,6 +33,8 @@ public:
   void modifyIMatrix(Eigen::MatrixXd &i, Eigen::MatrixXd &v, int MAX_NODE_ID,
                      double t, double deltaT) override {}
 
+  void incTime(Circuit *circuit) override {}
+
 private:
   double R;
   int PIN1;

--- a/src/Elements/ResistorElement.h
+++ b/src/Elements/ResistorElement.h
@@ -18,7 +18,7 @@ public:
   int getVoltageSourceCount() override { return 0; }
 
   void modifyGMatrix(Eigen::MatrixXd &g, Eigen::MatrixXd &v, int MAX_NODE_ID,
-                     double t) override {
+                     double t, double deltaT) override {
     double g0 = 1.0 / R;
     if (PIN1 != -1)
       g(PIN1, PIN1) += g0;
@@ -31,7 +31,7 @@ public:
   }
 
   void modifyIMatrix(Eigen::MatrixXd &i, Eigen::MatrixXd &v, int MAX_NODE_ID,
-                     double t) override {}
+                     double t, double deltaT) override {}
 
 private:
   double R;

--- a/src/Elements/VoltageSourceElement.h
+++ b/src/Elements/VoltageSourceElement.h
@@ -20,7 +20,7 @@ public:
 
 
   void modifyGMatrix(Eigen::MatrixXd &g, Eigen::MatrixXd &v, int MAX_NODE_ID,
-                     double t) override {
+                     double t, double deltaT) override {
     // std::cout << "modifying" << std::endl;
     // std::cout << "pin1" << pin1 << std::endl;
     // std::cout << "pin2" << pin2 << std::endl;
@@ -42,7 +42,7 @@ public:
   }
 
   void modifyIMatrix(Eigen::MatrixXd &i, Eigen::MatrixXd &v, int MAX_NODE_ID,
-                     double t) override {
+                     double t, double deltaT) override {
     i(MAX_NODE_ID + 1 + voltageSourceID) = this->v;
 
     // std::cout << "voltageSourceISuccess" << std::endl;

--- a/src/Elements/VoltageSourceElement.h
+++ b/src/Elements/VoltageSourceElement.h
@@ -48,6 +48,8 @@ public:
     // std::cout << "voltageSourceISuccess" << std::endl;
   }
 
+  void incTime(Circuit *circuit) override {}
+
   int getVoltageSourceCount() override { return 1; }
 
 private:

--- a/src/Line.h
+++ b/src/Line.h
@@ -37,17 +37,19 @@ void showLine(sf::RenderWindow *window, sf::Vector2f &point1,
 }
 
 void voltToColor(double voltage, sf::Color &color) {
+  double MAX_VOLT = 2;
+  double NEG_MAX_VOLT = -2;
   if (voltage >= 0) {
-    if (voltage >= 1)
-      voltage = 1;
+    if (voltage >= MAX_VOLT)
+      voltage = MAX_VOLT;
     color.a = 255;
     color.r = 30;
-    color.g = 30 + (255 - 30) * voltage;
+    color.g = 30 + (255 - 30) * (voltage / MAX_VOLT);
   } else {
-    if (voltage <= -1)
-      voltage = -1;
+    if (voltage <= NEG_MAX_VOLT)
+      voltage = NEG_MAX_VOLT;
     color.a = 255;
-    color.r = 30 + (255 - 30) * voltage * (-1);
+    color.r = 30 + (255 - 30) * (voltage / NEG_MAX_VOLT);
     color.g = 30;
     color.b = 30;
   }

--- a/src/UICircuit.h
+++ b/src/UICircuit.h
@@ -135,7 +135,7 @@ private:
   std::unordered_map<std::string, int> locToPinID;
   std::unique_ptr<Circuit> displayingCircuit;
   int nextPinID = 0;
-  double currentScale = 0.1;
+  double currentScale = 100;
 
   // infos
 public:

--- a/src/UICircuit.h
+++ b/src/UICircuit.h
@@ -206,7 +206,7 @@ public:
   double getDeltaT() { return deltaT; }
 
 private:
-  double deltaT = 0.0001;
+  double deltaT = 0.00001;
   // TODO:  remember to lock this function outside of calls
   bool buildCircuit() {
     std::cout << "Rebuild Circuit" << std::endl;

--- a/src/UICircuit.h
+++ b/src/UICircuit.h
@@ -135,7 +135,7 @@ private:
   std::unordered_map<std::string, int> locToPinID;
   std::unique_ptr<Circuit> displayingCircuit;
   int nextPinID = 0;
-  double currentScale = 1;
+  double currentScale = 0.1;
 
   // infos
 public:
@@ -426,7 +426,13 @@ private:
 
 private:
   int nextUIElementID = 0;
-
+public:
+  int getUIElementIDForUIElement(UIElement* elementPtr) {
+    uiElementIDToUIElement[nextUIElementID] = elementPtr;
+    nextUIElementID++; 
+    return nextUIElementID-1;
+  }
+private:
   void resetCircuit() {
     std::cout << "RESET: trying to obtain bufferCircuits lock" << std::endl;
     std::unique_lock<std::mutex> bufferCircuitsUniqueLock(bufferCircuitsLock);
@@ -447,10 +453,6 @@ private:
 public:
   void addElement(std::unique_ptr<UIElement> &uiElement) {
     resetCircuit();
-    uiElement->setUIElementID(nextUIElementID);
-    uiElementIDToUIElement[nextUIElementID] = uiElement.get();
-    nextUIElementID++;
-
     uiElements.push_back(std::move(uiElement));
   }
 

--- a/src/UICircuit.h
+++ b/src/UICircuit.h
@@ -132,7 +132,7 @@ private:
   std::unordered_map<std::string, int> locToPinID;
   std::unique_ptr<Circuit> displayingCircuit;
   int nextPinID = 0;
-  double currentScale = 1000;
+  double currentScale = 1;
 
   // infos
 public:
@@ -202,6 +202,7 @@ public:
   UIElement *getUIElement(int id) { return uiElementIDToUIElement[id]; }
 
 private:
+  double deltaT = 0.01;
   // TODO:  remember to lock this function outside of calls
   bool buildCircuit() {
     std::cout << "Rebuild Circuit" << std::endl;
@@ -244,7 +245,7 @@ private:
       return false;
     }
 
-    circuit = Circuit::create(elements, 0.01, nextPinID - 1);
+    circuit = Circuit::create(elements, deltaT, nextPinID - 1);
     return true;
   }
 

--- a/src/UICircuit.h
+++ b/src/UICircuit.h
@@ -53,7 +53,7 @@ private:
         }
 
         circuit->incTimerByDeltaT();
-
+        
         bool passed = false;
         bool hasOscillation = false;
 
@@ -67,6 +67,8 @@ private:
         //
         double iterationDrag = 1.1;
 
+        // set pre
+        circuit->setPreVAndPreI();
         while (true) {
           circuit->iterate(iteration, iterationDrag, &passed, &hasOscillation);
           if (hasOscillation) {
@@ -99,8 +101,9 @@ private:
           continue;
         }
 
+        // std::cout << "C:" << circuit->getCircuitID() << std::endl;
         std::unique_ptr<Circuit> pastCircuit =
-            std::make_unique<Circuit>(*circuit);
+            std::make_unique<Circuit>(*(circuit.get()));
         bufferCircuits.push(std::move(pastCircuit));
         // std::cout << "Buffer Circuit Count: " << bufferCircuits.size()
         //           << std::endl;
@@ -132,7 +135,7 @@ private:
   std::unordered_map<std::string, int> locToPinID;
   std::unique_ptr<Circuit> displayingCircuit;
   int nextPinID = 0;
-  double currentScale = 1;
+  double currentScale = 1000;
 
   // infos
 public:

--- a/src/UICircuit.h
+++ b/src/UICircuit.h
@@ -135,7 +135,7 @@ private:
   std::unordered_map<std::string, int> locToPinID;
   std::unique_ptr<Circuit> displayingCircuit;
   int nextPinID = 0;
-  double currentScale = 1000;
+  double currentScale = 10;
 
   // infos
 public:

--- a/src/UICircuit.h
+++ b/src/UICircuit.h
@@ -52,7 +52,6 @@ private:
           continue;
         }
 
-        circuit->incTimerByDeltaT();
         
         bool passed = false;
         bool hasOscillation = false;
@@ -111,6 +110,7 @@ private:
         // std::cout << "Unlock from calculating buffering circuit" <<
         // std::endl;
       }
+      circuit->incTimerByDeltaT();
     }
   }
 
@@ -168,10 +168,10 @@ public:
         // std::endl;
         tryNextTime = false;
       } else if (bufferCircuits.empty()) {
-        std::cout << "Circuits in buffer is empty. Circuit not valid or sim "
-                     "cannot keep up"
-                     ".. Circuit Simulation might slow Down"
-                  << std::endl;
+        // std::cout << "Circuits in buffer is empty. Circuit not valid or sim "
+        //              "cannot keep up"
+        //              ".. Circuit Simulation might slow Down"
+        //           << std::endl;
         tryNextTime = true;
       }
     }
@@ -203,9 +203,10 @@ private:
 
 public:
   UIElement *getUIElement(int id) { return uiElementIDToUIElement[id]; }
+  double getDeltaT() { return deltaT; }
 
 private:
-  double deltaT = 0.01;
+  double deltaT = 0.0001;
   // TODO:  remember to lock this function outside of calls
   bool buildCircuit() {
     std::cout << "Rebuild Circuit" << std::endl;

--- a/src/UICircuit.h
+++ b/src/UICircuit.h
@@ -57,7 +57,7 @@ private:
         bool passed = false;
         bool hasOscillation = false;
 
-        int MAX_ITERATION = 150;
+        int MAX_ITERATION = 10000;
 
         int iteration = 1;
         // must be greater than 1

--- a/src/UICircuit.h
+++ b/src/UICircuit.h
@@ -40,7 +40,7 @@ private:
 
         std::unique_lock<std::mutex> bufferCircuitsUniqueLock(
             bufferCircuitsLock);
-        if (bufferCircuits.size() >= 3) {
+        if (bufferCircuits.size() >= 1000) {
           bufferCircuitsUniqueLock.unlock();
           std::this_thread::sleep_for(std::chrono::nanoseconds(1000));
           continue;
@@ -57,7 +57,7 @@ private:
         bool passed = false;
         bool hasOscillation = false;
 
-        int MAX_ITERATION = 10000;
+        int MAX_ITERATION = 1000;
 
         int iteration = 1;
         // must be greater than 1
@@ -135,7 +135,7 @@ private:
   std::unordered_map<std::string, int> locToPinID;
   std::unique_ptr<Circuit> displayingCircuit;
   int nextPinID = 0;
-  double currentScale = 10;
+  double currentScale = 1;
 
   // infos
 public:

--- a/src/UICircuit.h
+++ b/src/UICircuit.h
@@ -206,7 +206,7 @@ public:
   double getDeltaT() { return deltaT; }
 
 private:
-  double deltaT = 0.00001;
+  double deltaT = 0.00000001;
   // TODO:  remember to lock this function outside of calls
   bool buildCircuit() {
     std::cout << "Rebuild Circuit" << std::endl;

--- a/src/UIElement.h
+++ b/src/UIElement.h
@@ -19,7 +19,7 @@ public:
   virtual void resetElement() = 0;
 public:
 
-  UIElement() {};
+  UIElement() {}
   std::vector<std::string> getConnectedLocs() {
     return connectedLocs;  
   }
@@ -46,9 +46,6 @@ public:
 protected:
   int uiElementID;
 public:
-  void setUIElementID(int id) {
-    uiElementID = id;
-  }
 };
 
 

--- a/src/UIElement.h
+++ b/src/UIElement.h
@@ -36,6 +36,8 @@ public:
 
   };
   
+
+  // NOTE: element is the newest version elment in the simulation. Get Data From V, I, PreviousV, and PreviousI Matrixes
   virtual void showElement(sf::RenderWindow* window) = 0;
 
   // if there is no circuit element return nullptr

--- a/src/UIElement.h
+++ b/src/UIElement.h
@@ -42,7 +42,7 @@ public:
   // Called when UICircuit is building himself
   // Will Rewrite uiCircuit
   virtual CircuitElement* getCircuitElementPointer() = 0;
-  // virtual void showUnCalculated() = 0;
+
 protected:
   int uiElementID;
 public:

--- a/src/UIElements/AdjustableVoltageSourceUIElement.h
+++ b/src/UIElements/AdjustableVoltageSourceUIElement.h
@@ -10,7 +10,6 @@
 #include <cmath>
 #include <iostream>
 
-class UICircuit;
 
 class AdjustableVoltageSourceUIElement : public UIElement {
 public:
@@ -33,6 +32,7 @@ public:
     this->xGrid = xGrid;
     this->yGrid = yGrid;
     uiCircuit = circuit;
+    uiElementID = circuit->getUIElementIDForUIElement((UIElement*) this);
 
     std::string pin1Loc =
         std::to_string(xGrid) + "," + std::to_string(yGrid - 1);

--- a/src/UIElements/CapacitorUIElement.h
+++ b/src/UIElements/CapacitorUIElement.h
@@ -21,6 +21,19 @@ public:
     this->xGrid = xGrid;
     this->yGrid = yGrid;
     this->C = C;
+
+    std::string pin1Loc =
+        std::to_string(xGrid) + "," + std::to_string(yGrid - 1);
+    std::string pin2Loc =
+        std::to_string(xGrid) + "," + std::to_string(yGrid + 1);
+
+    this->connectedLocs.push_back(pin1Loc);
+    this->connectedLocs.push_back(pin2Loc);
+
+    std::cout << "Capacitor Init: " << std::endl;
+    std::cout << "  Pin1Loc: " << pin1Loc << std::endl;
+    std::cout << "  Pin2Loc: " << pin2Loc << std::endl;
+
   }
 
   CircuitElement *getCircuitElementPointer() override {
@@ -29,7 +42,7 @@ public:
           std::to_string(xGrid) + "," + std::to_string(yGrid - 1);
       std::string pin2Loc =
           std::to_string(xGrid) + "," + std::to_string(yGrid + 1);
-      element = CapacitorElement::create(C, 0, uiCircuit->getIDfromLoc(pin1Loc),
+      element = CapacitorElement::create(C, 1, uiCircuit->getIDfromLoc(pin1Loc),
                                          uiCircuit->getIDfromLoc(pin2Loc));
       std::cout << "Capacitor Element Created!" << std::endl;
       std::cout << "Capacitor UI Element added to UI Circuit. ID: "
@@ -66,9 +79,9 @@ public:
                 // << "element:" << prePin1Volt - prePin2Volt << std::endl;
       double RI = (pin1Volt - pin2Volt) /
                   CapacitorElement::getInnerResistance(
-                      element->getDeltaT(), prePin1Volt - prePin2Volt, C);
+                      uiCircuit->getDeltaT(), prePin1Volt - prePin2Volt, C);
       double InnerI = CapacitorElement::getInnerISource(
-          element->getDeltaT(), prePin1Volt - prePin2Volt, C);
+          uiCircuit->getDeltaT(), prePin1Volt - prePin2Volt, C);
 
       double i = RI + InnerI;
       showCapacitor(window, pin1Volt, pin2Volt, i, xGrid, yGrid,

--- a/src/UIElements/CapacitorUIElement.h
+++ b/src/UIElements/CapacitorUIElement.h
@@ -21,6 +21,7 @@ public:
     this->xGrid = xGrid;
     this->yGrid = yGrid;
     this->C = C;
+    uiElementID = circuit->getUIElementIDForUIElement((UIElement*) this);
 
     std::string pin1Loc =
         std::to_string(xGrid) + "," + std::to_string(yGrid - 1);
@@ -46,7 +47,7 @@ public:
           std::to_string(xGrid) + "," + std::to_string(yGrid + 1);
       std::string pinMLoc = "E" + std::to_string(uiElementID) + "PinM";
 
-      element = CapacitorElement::create(C, 1, uiCircuit->getIDfromLoc(pin1Loc),
+      element = CapacitorElement::create(C, 2, uiCircuit->getIDfromLoc(pin1Loc),
                                          uiCircuit->getIDfromLoc(pin2Loc), uiCircuit->getIDfromLoc(pinMLoc), uiCircuit->getNextVoltageSourceID());
       std::cout << "Capacitor Element Created!" << std::endl;
       std::cout << "Capacitor UI Element added to UI Circuit. ID: "

--- a/src/UIElements/CapacitorUIElement.h
+++ b/src/UIElements/CapacitorUIElement.h
@@ -1,0 +1,123 @@
+#include "Line.h"
+#include "UIElement.h"
+#include <CapacitorElement.h>
+#include <SFML/Graphics/RenderWindow.hpp>
+#include <UICircuit.h>
+
+class CapacitorUIElement : public UIElement {
+public:
+  void resetElement() override {}
+
+private:
+  UICircuit *uiCircuit;
+  int xGrid, yGrid;
+  double C;
+  std::unique_ptr<CapacitorElement> element;
+
+public:
+  CapacitorUIElement(UICircuit *circuit, int xGrid, int yGrid, double C) {
+    uiCircuit = circuit;
+    this->xGrid = xGrid;
+    this->yGrid = yGrid;
+    this->C = C;
+  }
+
+  CircuitElement *getCircuitElementPointer() override {
+    if (element.get() == nullptr) {
+      std::string pin1Loc =
+          std::to_string(xGrid) + "," + std::to_string(yGrid - 1);
+      std::string pin2Loc =
+          std::to_string(xGrid) + "," + std::to_string(yGrid + 1);
+      element = CapacitorElement::create(C, 0,
+                                         uiCircuit->getIDfromLoc(pin1Loc),
+                                         uiCircuit->getIDfromLoc(pin2Loc));
+      std::cout << "Capacitor Element Created!" << std::endl;
+      std::cout << "Capacitor UI Element added to UI Circuit. ID: "
+                << uiElementID << std::endl;
+    }
+
+    return element.get();
+  }
+  void showElement(sf::RenderWindow *window) override {
+    if (element.get() == nullptr ||
+        uiCircuit->getDisplayCircuit() == nullptr) {
+      CapacitorUIElement::showGhostElement(window, xGrid, yGrid);
+    } else {
+      double pin1Volt = 0;
+      double pin2Volt = 0;
+      if (element->getPIN1() != -1) {
+        pin1Volt = *uiCircuit->getDisplayCircuit()->getVoltagePointer(
+            element->getPIN1());
+      }
+
+      if (element->getPIN2() != -1) {
+        pin2Volt = *uiCircuit->getDisplayCircuit()->getVoltagePointer(
+            element->getPIN2());
+      }
+
+      double i = (pin1Volt-pin2Volt) / element->getInnerResistance(element->getDeltaT()) + element->getInnerISource(element->getDeltaT());
+      std::cout << "I: " << i << std::endl;
+      std::cout << "PIN1: " << pin1Volt << "PIN2: " << pin2Volt << std::endl;
+      std::cout << "InnerR: " << element->getInnerResistance(element->getDeltaT()) << std::endl;
+      showCapacitor(window, pin1Volt, pin2Volt, i, xGrid, yGrid,
+                   uiCircuit->getCurrentScale());
+    }
+  }
+
+private:
+  static void showCapacitor(sf::RenderWindow *window, sf::Vector2f &loc,
+                            double v1, double v2) {
+    double width = 5;
+    sf::Vector2f pointP1(loc.x, loc.y - 50);
+    sf::Vector2f pointP2(loc.x, loc.y - 10);
+    sf::Vector2f pointP3(loc.x - 30, loc.y - 10);
+    sf::Vector2f pointP4(loc.x + 30, loc.y - 10);
+    sf::Vector2f pointM1(loc.x, loc.y + 50);
+    sf::Vector2f pointM2(loc.x, loc.y + 10);
+    sf::Vector2f pointM3(loc.x - 30, loc.y + 10);
+    sf::Vector2f pointM4(loc.x + 30, loc.y + 10);
+
+    sf::Color color1;
+    voltToColor(v1, color1);
+    sf::Color color2;
+    voltToColor(v2, color2);
+
+    showLine(window, pointP1, pointP2, width, color1, color1, color1);
+    showLine(window, pointP3, pointP4, width, color1, color1, color1);
+    showLine(window, pointM1, pointM2, width, color2, color2, color2);
+    showLine(window, pointM3, pointM4, width, color2, color2, color2);
+  }
+
+  double lastoffsetVolt = 0;
+  void showCapacitor(sf::RenderWindow *window, double v1, double v2, double i,
+                     sf::Vector2f &loc, double currentScale) {
+    CapacitorUIElement::showCapacitor(window, loc, v1, v2);
+
+    sf::Vector2f pointP1(loc.x, loc.y - 50);
+    double current = i;
+    lastoffsetVolt += current * currentScale;
+    lastoffsetVolt = std::remainder(lastoffsetVolt, 20);
+    lastoffsetVolt =
+        lastoffsetVolt < 0 ? lastoffsetVolt + 20.0 : lastoffsetVolt;
+    for (int i = 0; i < 5; ++i) {
+      sf::CircleShape circle(5.0 / 2);
+      circle.setPosition(pointP1.x - circle.getRadius(),
+                         pointP1.y + 20 * i - circle.getRadius() +
+                             lastoffsetVolt);
+      circle.setFillColor(sf::Color(200, 200, 0));
+      window->draw(circle);
+    }
+  }
+  void showCapacitor(sf::RenderWindow *window, double v1, double v2, double i,
+                     int xGrid, int yGrid, double currentScale) {
+    sf::Vector2f loc(xGrid*50, yGrid*50);
+    showCapacitor(window, v1, v2, i, loc, currentScale);
+  }
+
+
+private:
+  static void showGhostElement(sf::RenderWindow *window, int xGrid, int yGrid) {
+    sf::Vector2f loc(xGrid * 50, yGrid * 50);
+    CapacitorUIElement::showCapacitor(window, loc, 0, 0);
+  }
+};

--- a/src/UIElements/CapacitorUIElement.h
+++ b/src/UIElements/CapacitorUIElement.h
@@ -26,14 +26,16 @@ public:
         std::to_string(xGrid) + "," + std::to_string(yGrid - 1);
     std::string pin2Loc =
         std::to_string(xGrid) + "," + std::to_string(yGrid + 1);
+    std::string pinMLoc = "E" + std::to_string(uiElementID) + "PinM";
 
     this->connectedLocs.push_back(pin1Loc);
     this->connectedLocs.push_back(pin2Loc);
+    this->connectedLocs.push_back(pinMLoc);
 
     std::cout << "Capacitor Init: " << std::endl;
     std::cout << "  Pin1Loc: " << pin1Loc << std::endl;
     std::cout << "  Pin2Loc: " << pin2Loc << std::endl;
-
+    std::cout << "  PinMLoc: " << pinMLoc << std::endl;
   }
 
   CircuitElement *getCircuitElementPointer() override {
@@ -42,8 +44,10 @@ public:
           std::to_string(xGrid) + "," + std::to_string(yGrid - 1);
       std::string pin2Loc =
           std::to_string(xGrid) + "," + std::to_string(yGrid + 1);
+      std::string pinMLoc = "E" + std::to_string(uiElementID) + "PinM";
+
       element = CapacitorElement::create(C, 1, uiCircuit->getIDfromLoc(pin1Loc),
-                                         uiCircuit->getIDfromLoc(pin2Loc));
+                                         uiCircuit->getIDfromLoc(pin2Loc), uiCircuit->getIDfromLoc(pinMLoc), uiCircuit->getNextVoltageSourceID());
       std::cout << "Capacitor Element Created!" << std::endl;
       std::cout << "Capacitor UI Element added to UI Circuit. ID: "
                 << uiElementID << std::endl;
@@ -58,32 +62,23 @@ public:
     } else {
       double pin1Volt = 0;
       double pin2Volt = 0;
-      double prePin1Volt = 0;
-      double prePin2Volt = 0;
       if (element->getPIN1() != -1) {
         pin1Volt = *uiCircuit->getDisplayCircuit()->getVoltagePointer(
-            element->getPIN1());
-        prePin1Volt = *uiCircuit->getDisplayCircuit()->getPreVoltagePointer(
             element->getPIN1());
       }
 
       if (element->getPIN2() != -1) {
         pin2Volt = *uiCircuit->getDisplayCircuit()->getVoltagePointer(
             element->getPIN2());
-        prePin2Volt = *uiCircuit->getDisplayCircuit()->getPreVoltagePointer(
-            element->getPIN2());
       }
 
       // std::cout << "CID:" << uiCircuit->getDisplayCircuit()->getCircuitID()
-                // << "V1-V2:" << pin1Volt - pin2Volt
-                // << "element:" << prePin1Volt - prePin2Volt << std::endl;
-      double RI = (pin1Volt - pin2Volt) /
-                  CapacitorElement::getInnerResistance(
-                      uiCircuit->getDeltaT(), prePin1Volt - prePin2Volt, C);
-      double InnerI = CapacitorElement::getInnerISource(
-          uiCircuit->getDeltaT(), prePin1Volt - prePin2Volt, C);
-
-      double i = RI + InnerI;
+      // << "V1-V2:" << pin1Volt - pin2Volt
+      // << "element:" << prePin1Volt - prePin2Volt << std::endl;
+      double i =  *uiCircuit->getDisplayCircuit()->getVoltagePointer(
+              uiCircuit->getMaxNodeID() +
+              element->getVoltageSourceID() + 1);
+      
       showCapacitor(window, pin1Volt, pin2Volt, i, xGrid, yGrid,
                     uiCircuit->getCurrentScale());
     }

--- a/src/UIElements/CurrentSourceUIElement.h
+++ b/src/UIElements/CurrentSourceUIElement.h
@@ -109,8 +109,8 @@ private:
     sf::Vector2f point22(loc.x, loc.y + 25);
     sf::Vector2f pointC1(loc.x, loc.y - 20);
     sf::Vector2f pointC2(loc.x, loc.y + 20);
-    sf::Vector2f pointC11(loc.x + 2.5, loc.y - 15);
-    sf::Vector2f pointC12(loc.x - 2.5, loc.y - 15);
+    sf::Vector2f pointC11(loc.x + 10, loc.y - 10);
+    sf::Vector2f pointC12(loc.x - 10, loc.y - 10);
     // sf::Vector2f pointADD1(loc.x - 10, loc.y - 10);
     // sf::Vector2f pointADD2(loc.x + 10, loc.y - 10);
     // sf::Vector2f pointADD3(loc.x, loc.y - 10 + 10);

--- a/src/UIElements/CurrentSourceUIElement.h
+++ b/src/UIElements/CurrentSourceUIElement.h
@@ -32,6 +32,7 @@ public:
     this->xGrid = xGrid;
     this->yGrid = yGrid;
     uiCircuit = circuit;
+    uiElementID = circuit->getUIElementIDForUIElement((UIElement*) this);
 
     std::string pin1Loc =
         std::to_string(xGrid) + "," + std::to_string(yGrid - 1);

--- a/src/UIElements/CurrentSourceUIElement.h
+++ b/src/UIElements/CurrentSourceUIElement.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#include "Line.h"
+#include <CurrentSourceElement.h>
+#include <SFML/Graphics.hpp>
+#include <SFML/Graphics/RenderWindow.hpp>
+#include <SFML/System/Vector2.hpp>
+#include <UICircuit.h>
+#include <UIElement.h>
+#include <cmath>
+#include <iostream>
+
+class UICircuit;
+
+class CurrentSourceUIElement : public UIElement {
+public:
+  static void showGhostElement(sf::RenderWindow *window, int xGrid, int yGrid) {
+    sf::Vector2f loc(xGrid * 50, yGrid * 50);
+    CurrentSourceUIElement::showElement(window, loc, 0, 0);
+  }
+
+private:
+  std::unique_ptr<CurrentSourceElement> element;
+
+private:
+  double i;
+  UICircuit *uiCircuit;
+
+public:
+  CurrentSourceUIElement(UICircuit *circuit, int xGrid, int yGrid, double i) {
+    this->i = i;
+    this->xGrid = xGrid;
+    this->yGrid = yGrid;
+    uiCircuit = circuit;
+
+    std::string pin1Loc =
+        std::to_string(xGrid) + "," + std::to_string(yGrid - 1);
+    std::string pin2Loc =
+        std::to_string(xGrid) + "," + std::to_string(yGrid + 1);
+
+    this->connectedLocs.push_back(pin1Loc);
+    this->connectedLocs.push_back(pin2Loc);
+
+    std::cout << "Current Source Init:" << std::endl;
+    std::cout << "  Pin1Loc: " << pin1Loc << std::endl;
+    std::cout << "  Pin2Loc: " << pin2Loc << std::endl;
+  }
+
+  void showElement(sf::RenderWindow *window) override {
+    if (element.get() == nullptr || uiCircuit->getDisplayCircuit() == nullptr) {
+      // show Ghost Version
+      CurrentSourceUIElement::showGhostElement(window, xGrid, yGrid);
+    } else {
+      double pin1Volt = 0;
+      double pin2Volt = 0;
+      if (element->getPin1() != -1) {
+        pin1Volt = *uiCircuit->getDisplayCircuit()->getVoltagePointer(
+            element->getPin1());
+      }
+
+      if (element->getPin2() != -1) {
+        pin2Volt = *uiCircuit->getDisplayCircuit()->getVoltagePointer(
+            element->getPin2());
+      }
+
+      showCurrentSource(window, pin1Volt, pin2Volt, i, xGrid, yGrid,
+                        uiCircuit->getCurrentScale());
+    }
+  }
+
+  CircuitElement *getCircuitElementPointer() override {
+    if (element.get() == nullptr) {
+      std::string pin1Loc =
+          std::to_string(xGrid) + "," + std::to_string(yGrid - 1);
+      std::string pin2Loc =
+          std::to_string(xGrid) + "," + std::to_string(yGrid + 1);
+
+      element =
+          CurrentSourceElement::create(i, uiCircuit->getIDfromLoc(pin1Loc),
+                                       uiCircuit->getIDfromLoc(pin2Loc));
+      std::cout << "Current Source Element Created!" << std::endl;
+      std::cout << "Current Source UI Element added to UI Circuit. ID: "
+                << uiElementID << std::endl;
+    }
+    return element.get();
+  }
+
+  void resetElement() override { element.reset(); }
+
+public:
+  ~CurrentSourceUIElement() override {};
+
+private:
+  double lastoffset = 0;
+  static void showElement(sf::RenderWindow *window, sf::Vector2f &loc,
+                          double v1, double v2) {
+    double width = 5;
+
+    sf::CircleShape circle(25);
+    circle.setFillColor(sf::Color(0, 0, 0));
+    circle.setOutlineThickness(width);
+    circle.setOutlineColor(sf::Color(30, 30, 30));
+
+    circle.setPosition(loc.x - circle.getRadius(), loc.y - circle.getRadius());
+
+    sf::Vector2f point11(loc.x, loc.y - 50);
+    sf::Vector2f point12(loc.x, loc.y - 25);
+    sf::Vector2f point21(loc.x, loc.y + 50);
+    sf::Vector2f point22(loc.x, loc.y + 25);
+    sf::Vector2f pointC1(loc.x, loc.y - 20);
+    sf::Vector2f pointC2(loc.x, loc.y + 20);
+    sf::Vector2f pointC11(loc.x + 2.5, loc.y - 15);
+    sf::Vector2f pointC12(loc.x - 2.5, loc.y - 15);
+    // sf::Vector2f pointADD1(loc.x - 10, loc.y - 10);
+    // sf::Vector2f pointADD2(loc.x + 10, loc.y - 10);
+    // sf::Vector2f pointADD3(loc.x, loc.y - 10 + 10);
+    // sf::Vector2f pointADD4(loc.x, loc.y - 10 - 10);
+    // sf::Vector2f pointMINUS1(loc.x - 10, loc.y + 12.5);
+    // sf::Vector2f pointMINUS2(loc.x + 10, loc.y + 12.5);
+
+    sf::Color color1;
+    voltToColor(v1, color1);
+    sf::Color color2;
+    voltToColor(v2, color2);
+
+    showLine(window, point11, point12, width, color1, color1, color1);
+    showLine(window, point21, point22, width, color2, color2, color2);
+
+    window->draw(circle);
+
+    showLine(window, pointC1, pointC2, width, sf::Color(30, 30, 30),
+             sf::Color(30, 30, 30), sf::Color(30, 30, 30));
+    showLine(window, pointC1, pointC11, width, sf::Color(30, 30, 30),
+             sf::Color(30, 30, 30), sf::Color(30, 30, 30));
+    showLine(window, pointC1, pointC12, width, sf::Color(30, 30, 30),
+             sf::Color(30, 30, 30), sf::Color(30, 30, 30));
+  }
+  void showCurrentSource(sf::RenderWindow *window, double v1, double v2,
+                         double i, sf::Vector2f &loc, double currentScale) {
+    showElement(window, loc, v1, v2);
+    sf::Vector2f pointP1(loc.x, loc.y - 50);
+
+    double current = -i;
+    lastoffset += current * currentScale;
+    lastoffset = std::remainder(lastoffset, 20);
+    lastoffset = lastoffset < 0 ? lastoffset + 20.0 : lastoffset;
+    for (int index = 0; index < 5; ++index) {
+      sf::CircleShape circle(5.0 / 2);
+      circle.setPosition(pointP1.x - circle.getRadius(),
+                         pointP1.y + 20 * index - circle.getRadius() + lastoffset);
+      circle.setFillColor(sf::Color(200, 200, 0));
+      window->draw(circle);
+    }
+  }
+
+  void showCurrentSource(sf::RenderWindow *window, double v1, double v2,
+                         double i, int xGrid, int yGrid, double currentScale) {
+    sf::Vector2f loc(xGrid * 50, yGrid * 50);
+    showCurrentSource(window, v1, v2, i, loc, currentScale);
+  }
+};

--- a/src/UIElements/GroundUIElement.h
+++ b/src/UIElements/GroundUIElement.h
@@ -1,6 +1,7 @@
 #include <UIElement.h>
 #include <Line.h>
 #include <iostream>
+#include <UICircuit.h>
 
 class GroundUIElement : public UIElement {
 public:
@@ -9,6 +10,7 @@ public:
     uiCircuit = circuit;
     this->xGrid = xGrid;
     this->yGrid = yGrid;
+    uiElementID = circuit->getUIElementIDForUIElement((UIElement*) this);
 
     std::string pinLoc = std::to_string(xGrid) + "," + std::to_string(yGrid);
 

--- a/src/UIElements/InductorUIElement.h
+++ b/src/UIElements/InductorUIElement.h
@@ -7,7 +7,7 @@
 
 class InductorUIElement : public UIElement {
 public:
-  void resetElement() override {}
+  void resetElement() override { element.reset(); }
 
 private:
   UICircuit *uiCircuit;
@@ -21,31 +21,37 @@ public:
     this->xGrid = xGrid;
     this->yGrid = yGrid;
     this->L = L;
-    uiElementID = circuit->getUIElementIDForUIElement((UIElement*) this);
+    uiElementID = circuit->getUIElementIDForUIElement((UIElement *)this);
 
     std::string pin1Loc =
         std::to_string(xGrid) + "," + std::to_string(yGrid - 1);
+    std::string pinMLoc = "E" + std::to_string(uiElementID) + "PinM";
     std::string pin2Loc =
         std::to_string(xGrid) + "," + std::to_string(yGrid + 1);
-    
+
     this->connectedLocs.push_back(pin1Loc);
+    this->connectedLocs.push_back(pinMLoc);
     this->connectedLocs.push_back(pin2Loc);
 
     std::cout << "Inductor Init: " << std::endl;
     std::cout << "  Pin1Loc: " << pin1Loc << std::endl;
+    std::cout << "  PinMLoc (0 Volt Voltage Source): " << pinMLoc << std::endl;
     std::cout << "  Pin2Loc: " << pin2Loc << std::endl;
-
   }
 
   CircuitElement *getCircuitElementPointer() override {
     if (element.get() == nullptr) {
       std::string pin1Loc =
           std::to_string(xGrid) + "," + std::to_string(yGrid - 1);
+      std::string pinMLoc = "E" + std::to_string(uiElementID) + "PinM";
       std::string pin2Loc =
           std::to_string(xGrid) + "," + std::to_string(yGrid + 1);
 
       element = InductorElement::create(L, 0, uiCircuit->getIDfromLoc(pin1Loc),
-                                         uiCircuit->getIDfromLoc(pin2Loc));
+                                        uiCircuit->getIDfromLoc(pinMLoc),
+                                        uiCircuit->getIDfromLoc(pin2Loc),
+                                        uiCircuit->getNextVoltageSourceID());
+
       std::cout << "Inductor Element Created!" << std::endl;
       std::cout << "Inductor UI Element added to UI Circuit. ID: "
                 << uiElementID << std::endl;
@@ -75,29 +81,22 @@ public:
         prePin2Volt = *uiCircuit->getDisplayCircuit()->getPreVoltagePointer(
             element->getPIN2());
       }
-      
 
       // std::cout << "CID:" << uiCircuit->getDisplayCircuit()->getCircuitID()
-                // << "V1-V2:" << pin1Volt - pin2Volt
-                // << "element:" << prePin1Volt - prePin2Volt << std::endl;
-      // double RI = (pin1Volt - pin2Volt) *
-      //             InductorElement::getInnerConductance(
-      //                 uiCircuit->getDeltaT(), prePin1Volt - prePin2Volt, L);
-      // double InnerI = InductorElement::getInnerISource(
-      //     uiCircuit->getDeltaT(), prePin1Volt - prePin2Volt, L);
-      //
-      // double i = RI + InnerI;
-      //
-      double i = 0;
-       
+      // << "V1-V2:" << pin1Volt - pin2Volt
+      // << "element:" << prePin1Volt - prePin2Volt << std::endl;
+
+      double i = *uiCircuit->getDisplayCircuit()->getVoltagePointer(
+          uiCircuit->getMaxNodeID() + element->getVoltageSourceID() + 1);
+
       showInductor(window, pin1Volt, pin2Volt, i, xGrid, yGrid,
-                    uiCircuit->getCurrentScale());
+                   uiCircuit->getCurrentScale());
     }
   }
 
 private:
   static void showInductor(sf::RenderWindow *window, sf::Vector2f &loc,
-                            double v1, double v2) {
+                           double v1, double v2) {
     double width = 5;
     sf::Vector2f point11(loc.x, loc.y - 50);
     sf::Vector2f point12(loc.x, loc.y - 10);
@@ -121,26 +120,24 @@ private:
 
   double lastoffset = 0;
   void showInductor(sf::RenderWindow *window, double v1, double v2, double i,
-                     sf::Vector2f &loc, double currentScale) {
+                    sf::Vector2f &loc, double currentScale) {
     InductorUIElement::showInductor(window, loc, v1, v2);
 
     sf::Vector2f point11(loc.x, loc.y - 50);
     double current = i;
     lastoffset += current * currentScale;
     lastoffset = std::remainder(lastoffset, 20);
-    lastoffset =
-        lastoffset < 0 ? lastoffset + 20.0 : lastoffset;
+    lastoffset = lastoffset < 0 ? lastoffset + 20.0 : lastoffset;
     for (int i = 0; i < 5; ++i) {
       sf::CircleShape circle(5.0 / 2);
       circle.setPosition(point11.x - circle.getRadius(),
-                         point11.y + 20 * i - circle.getRadius() +
-                             lastoffset);
+                         point11.y + 20 * i - circle.getRadius() + lastoffset);
       circle.setFillColor(sf::Color(200, 200, 0));
       window->draw(circle);
     }
   }
   void showInductor(sf::RenderWindow *window, double v1, double v2, double i,
-                     int xGrid, int yGrid, double currentScale) {
+                    int xGrid, int yGrid, double currentScale) {
     sf::Vector2f loc(xGrid * 50, yGrid * 50);
     showInductor(window, v1, v2, i, loc, currentScale);
   }

--- a/src/UIElements/InductorUIElement.h
+++ b/src/UIElements/InductorUIElement.h
@@ -26,17 +26,13 @@ public:
         std::to_string(xGrid) + "," + std::to_string(yGrid - 1);
     std::string pin2Loc =
         std::to_string(xGrid) + "," + std::to_string(yGrid + 1);
-    std::string pinMLoc =
-        "E" + std::to_string(uiElementID) + "PinM";
-
+    
     this->connectedLocs.push_back(pin1Loc);
     this->connectedLocs.push_back(pin2Loc);
-    this->connectedLocs.push_back(pinMLoc);
 
     std::cout << "Inductor Init: " << std::endl;
     std::cout << "  Pin1Loc: " << pin1Loc << std::endl;
     std::cout << "  Pin2Loc: " << pin2Loc << std::endl;
-    std::cout << "  PinMLoc: " << pinMLoc << std::endl;
 
   }
 
@@ -46,11 +42,9 @@ public:
           std::to_string(xGrid) + "," + std::to_string(yGrid - 1);
       std::string pin2Loc =
           std::to_string(xGrid) + "," + std::to_string(yGrid + 1);
-      std::string pinMLoc =
-        "E" + std::to_string(uiElementID) + "PinM";
 
       element = InductorElement::create(L, 0, uiCircuit->getIDfromLoc(pin1Loc),
-                                         uiCircuit->getIDfromLoc(pin2Loc), uiCircuit->getIDfromLoc(pinMLoc), uiCircuit->getNextVoltageSourceID());
+                                         uiCircuit->getIDfromLoc(pin2Loc));
       std::cout << "Inductor Element Created!" << std::endl;
       std::cout << "Inductor UI Element added to UI Circuit. ID: "
                 << uiElementID << std::endl;
@@ -65,22 +59,36 @@ public:
     } else {
       double pin1Volt = 0;
       double pin2Volt = 0;
+      double prePin1Volt = 0;
+      double prePin2Volt = 0;
       if (element->getPIN1() != -1) {
         pin1Volt = *uiCircuit->getDisplayCircuit()->getVoltagePointer(
+            element->getPIN1());
+        prePin1Volt = *uiCircuit->getDisplayCircuit()->getPreVoltagePointer(
             element->getPIN1());
       }
 
       if (element->getPIN2() != -1) {
         pin2Volt = *uiCircuit->getDisplayCircuit()->getVoltagePointer(
             element->getPIN2());
+        prePin2Volt = *uiCircuit->getDisplayCircuit()->getPreVoltagePointer(
+            element->getPIN2());
       }
+      
 
       // std::cout << "CID:" << uiCircuit->getDisplayCircuit()->getCircuitID()
                 // << "V1-V2:" << pin1Volt - pin2Volt
                 // << "element:" << prePin1Volt - prePin2Volt << std::endl;
-      double i =  *uiCircuit->getDisplayCircuit()->getVoltagePointer(
-              uiCircuit->getMaxNodeID() +
-              element->getVoltageSourceID() + 1); 
+      // double RI = (pin1Volt - pin2Volt) *
+      //             InductorElement::getInnerConductance(
+      //                 uiCircuit->getDeltaT(), prePin1Volt - prePin2Volt, L);
+      // double InnerI = InductorElement::getInnerISource(
+      //     uiCircuit->getDeltaT(), prePin1Volt - prePin2Volt, L);
+      //
+      // double i = RI + InnerI;
+      //
+      double i = 0;
+       
       showInductor(window, pin1Volt, pin2Volt, i, xGrid, yGrid,
                     uiCircuit->getCurrentScale());
     }

--- a/src/UIElements/InductorUIElement.h
+++ b/src/UIElements/InductorUIElement.h
@@ -60,7 +60,6 @@ public:
     return element.get();
   }
   void showElement(sf::RenderWindow *window) override {
-    // FIXME: element is the newest version. to get the rendered version use
     if (element.get() == nullptr || uiCircuit->getDisplayCircuit() == nullptr) {
       InductorUIElement::showGhostElement(window, xGrid, yGrid);
     } else {
@@ -98,24 +97,50 @@ private:
   static void showInductor(sf::RenderWindow *window, sf::Vector2f &loc,
                            double v1, double v2) {
     double width = 5;
-    sf::Vector2f point11(loc.x, loc.y - 50);
-    sf::Vector2f point12(loc.x, loc.y - 10);
-    // sf::Vector2f pointP3(loc.x - 30, loc.y - 10);
-    // sf::Vector2f pointP4(loc.x + 30, loc.y - 10);
-    sf::Vector2f point21(loc.x, loc.y + 50);
-    sf::Vector2f point22(loc.x, loc.y + 10);
-    // sf::Vector2f pointM3(loc.x - 30, loc.y + 10);
-    // sf::Vector2f pointM4(loc.x + 30, loc.y + 10);
+
+    sf::Vector2f pointP11(loc.x, loc.y-50);
+    sf::Vector2f pointP12(loc.x, loc.y-40);
+    sf::Vector2f pointP13(loc.x+20, loc.y-30);
+    sf::Vector2f pointPC11(loc.x+20, loc.y-20);
+    sf::Vector2f pointPC12(loc.x, loc.y-10);
+    sf::Vector2f pointPC13(loc.x-20, loc.y-20);
+    sf::Vector2f pointPC14(loc.x, loc.y-30);
+    sf::Vector2f pointPC15(loc.x+20, loc.y-10);
+    sf::Vector2f pointPC21(loc.x+20, loc.y+10);
+    sf::Vector2f pointPC22(loc.x, loc.y+20);
+    sf::Vector2f pointPC23(loc.x-20, loc.y+10);
+    sf::Vector2f pointPC24(loc.x, loc.y);
+    sf::Vector2f pointPC25(loc.x+20, loc.y+20);
+    sf::Vector2f pointP23(loc.x+20, loc.y+30);
+    sf::Vector2f pointP22(loc.x, loc.y+40);
+    sf::Vector2f pointP21(loc.x, loc.y+50);
 
     sf::Color color1;
     voltToColor(v1, color1);
     sf::Color color2;
     voltToColor(v2, color2);
-
-    showLine(window, point11, point12, width, color1, color1, color1);
-    // showLine(window, pointP3, pointP4, width, color1, color1, color1);
-    showLine(window, point21, point22, width, color2, color2, color2);
-    // showLine(window, pointM3, pointM4, width, color2, color2, color2);
+    sf::Color colorPC1;
+    sf::Color colorPC2;
+    sf::Color colorPCM;
+    midColor(colorPCM, color1, color2);
+    midColor(colorPC1, color1, colorPCM);
+    midColor(colorPC2, color2, colorPCM);
+    
+    showLine(window, pointP11, pointP12, width, color1, color1, color1);
+    showLine(window, pointP12, pointP13, width, color1, color1, color1);
+    showLine(window, pointP13, pointPC11, width, color1, color1, color1);
+    showLine(window, pointPC11, pointPC12, width, color1, color1, colorPC1);
+    showLine(window, pointPC12, pointPC13, width, colorPC1, colorPC1, colorPC1);
+    showLine(window, pointPC13, pointPC14, width, colorPC1, colorPC1, colorPC1);
+    showLine(window, pointPC14, pointPC15, width, colorPC1, colorPC1, colorPCM);
+    showLine(window, pointPC15, pointPC21, width, colorPCM, colorPC2, colorPC2);
+    showLine(window, pointPC21, pointPC22, width, colorPC2, colorPC2, colorPC2);
+    showLine(window, pointPC22, pointPC23, width, colorPC2, colorPC2, colorPC2);
+    showLine(window, pointPC23, pointPC24, width, colorPC2, colorPC2, colorPC2);
+    showLine(window, pointPC24, pointPC25, width, colorPC2, color2, color2);
+    showLine(window, pointPC25, pointP23, width, color2, color2, color2);
+    showLine(window, pointP23, pointP22, width, color2, color2, color2);
+    showLine(window, pointP22, pointP21, width, color2, color2, color2);
   }
 
   double lastoffset = 0;

--- a/src/UIElements/InductorUIElement.h
+++ b/src/UIElements/InductorUIElement.h
@@ -1,0 +1,144 @@
+#pragma once
+#include "Line.h"
+#include "UIElement.h"
+#include <InductorElement.h>
+#include <SFML/Graphics/RenderWindow.hpp>
+#include <UICircuit.h>
+
+class InductorUIElement : public UIElement {
+public:
+  void resetElement() override {}
+
+private:
+  UICircuit *uiCircuit;
+  int xGrid, yGrid;
+  double L;
+  std::unique_ptr<InductorElement> element;
+
+public:
+  InductorUIElement(UICircuit *circuit, int xGrid, int yGrid, double L) {
+    uiCircuit = circuit;
+    this->xGrid = xGrid;
+    this->yGrid = yGrid;
+    this->L = L;
+
+    std::string pin1Loc =
+        std::to_string(xGrid) + "," + std::to_string(yGrid - 1);
+    std::string pin2Loc =
+        std::to_string(xGrid) + "," + std::to_string(yGrid + 1);
+    std::string pinMLoc =
+        "E" + std::to_string(uiElementID) + "PinM";
+
+    this->connectedLocs.push_back(pin1Loc);
+    this->connectedLocs.push_back(pin2Loc);
+    this->connectedLocs.push_back(pinMLoc);
+
+    std::cout << "Inductor Init: " << std::endl;
+    std::cout << "  Pin1Loc: " << pin1Loc << std::endl;
+    std::cout << "  Pin2Loc: " << pin2Loc << std::endl;
+    std::cout << "  PinMLoc: " << pinMLoc << std::endl;
+
+  }
+
+  CircuitElement *getCircuitElementPointer() override {
+    if (element.get() == nullptr) {
+      std::string pin1Loc =
+          std::to_string(xGrid) + "," + std::to_string(yGrid - 1);
+      std::string pin2Loc =
+          std::to_string(xGrid) + "," + std::to_string(yGrid + 1);
+      std::string pinMLoc =
+        "E" + std::to_string(uiElementID) + "PinM";
+
+      element = InductorElement::create(L, 0, uiCircuit->getIDfromLoc(pin1Loc),
+                                         uiCircuit->getIDfromLoc(pin2Loc), uiCircuit->getIDfromLoc(pinMLoc), uiCircuit->getNextVoltageSourceID());
+      std::cout << "Inductor Element Created!" << std::endl;
+      std::cout << "Inductor UI Element added to UI Circuit. ID: "
+                << uiElementID << std::endl;
+    }
+
+    return element.get();
+  }
+  void showElement(sf::RenderWindow *window) override {
+    // FIXME: element is the newest version. to get the rendered version use
+    if (element.get() == nullptr || uiCircuit->getDisplayCircuit() == nullptr) {
+      InductorUIElement::showGhostElement(window, xGrid, yGrid);
+    } else {
+      double pin1Volt = 0;
+      double pin2Volt = 0;
+      if (element->getPIN1() != -1) {
+        pin1Volt = *uiCircuit->getDisplayCircuit()->getVoltagePointer(
+            element->getPIN1());
+      }
+
+      if (element->getPIN2() != -1) {
+        pin2Volt = *uiCircuit->getDisplayCircuit()->getVoltagePointer(
+            element->getPIN2());
+      }
+
+      // std::cout << "CID:" << uiCircuit->getDisplayCircuit()->getCircuitID()
+                // << "V1-V2:" << pin1Volt - pin2Volt
+                // << "element:" << prePin1Volt - prePin2Volt << std::endl;
+      double i =  *uiCircuit->getDisplayCircuit()->getVoltagePointer(
+              uiCircuit->getMaxNodeID() +
+              element->getVoltageSourceID() + 1); 
+      showInductor(window, pin1Volt, pin2Volt, i, xGrid, yGrid,
+                    uiCircuit->getCurrentScale());
+    }
+  }
+
+private:
+  static void showInductor(sf::RenderWindow *window, sf::Vector2f &loc,
+                            double v1, double v2) {
+    double width = 5;
+    sf::Vector2f point11(loc.x, loc.y - 50);
+    sf::Vector2f point12(loc.x, loc.y - 10);
+    // sf::Vector2f pointP3(loc.x - 30, loc.y - 10);
+    // sf::Vector2f pointP4(loc.x + 30, loc.y - 10);
+    sf::Vector2f point21(loc.x, loc.y + 50);
+    sf::Vector2f point22(loc.x, loc.y + 10);
+    // sf::Vector2f pointM3(loc.x - 30, loc.y + 10);
+    // sf::Vector2f pointM4(loc.x + 30, loc.y + 10);
+
+    sf::Color color1;
+    voltToColor(v1, color1);
+    sf::Color color2;
+    voltToColor(v2, color2);
+
+    showLine(window, point11, point12, width, color1, color1, color1);
+    // showLine(window, pointP3, pointP4, width, color1, color1, color1);
+    showLine(window, point21, point22, width, color2, color2, color2);
+    // showLine(window, pointM3, pointM4, width, color2, color2, color2);
+  }
+
+  double lastoffset = 0;
+  void showInductor(sf::RenderWindow *window, double v1, double v2, double i,
+                     sf::Vector2f &loc, double currentScale) {
+    InductorUIElement::showInductor(window, loc, v1, v2);
+
+    sf::Vector2f point11(loc.x, loc.y - 50);
+    double current = i;
+    lastoffset += current * currentScale;
+    lastoffset = std::remainder(lastoffset, 20);
+    lastoffset =
+        lastoffset < 0 ? lastoffset + 20.0 : lastoffset;
+    for (int i = 0; i < 5; ++i) {
+      sf::CircleShape circle(5.0 / 2);
+      circle.setPosition(point11.x - circle.getRadius(),
+                         point11.y + 20 * i - circle.getRadius() +
+                             lastoffset);
+      circle.setFillColor(sf::Color(200, 200, 0));
+      window->draw(circle);
+    }
+  }
+  void showInductor(sf::RenderWindow *window, double v1, double v2, double i,
+                     int xGrid, int yGrid, double currentScale) {
+    sf::Vector2f loc(xGrid * 50, yGrid * 50);
+    showInductor(window, v1, v2, i, loc, currentScale);
+  }
+
+private:
+  static void showGhostElement(sf::RenderWindow *window, int xGrid, int yGrid) {
+    sf::Vector2f loc(xGrid * 50, yGrid * 50);
+    InductorUIElement::showInductor(window, loc, 0, 0);
+  }
+};

--- a/src/UIElements/InductorUIElement.h
+++ b/src/UIElements/InductorUIElement.h
@@ -21,6 +21,7 @@ public:
     this->xGrid = xGrid;
     this->yGrid = yGrid;
     this->L = L;
+    uiElementID = circuit->getUIElementIDForUIElement((UIElement*) this);
 
     std::string pin1Loc =
         std::to_string(xGrid) + "," + std::to_string(yGrid - 1);

--- a/src/UIElements/NMOSUIElement.h
+++ b/src/UIElements/NMOSUIElement.h
@@ -24,6 +24,7 @@ public:
   NMOSUIElement(UICircuit *circuit, int xGrid, int yGrid, double k, double vt,
                 double va) {
     uiCircuit = circuit;
+    uiElementID = circuit->getUIElementIDForUIElement((UIElement*) this);
     this->xGrid = xGrid;
     this->yGrid = yGrid;
 

--- a/src/UIElements/PMOSUIElement.h
+++ b/src/UIElements/PMOSUIElement.h
@@ -24,6 +24,7 @@ public:
   PMOSUIElement(UICircuit *circuit, int xGrid, int yGrid, double k, double vt,
                 double va) {
     uiCircuit = circuit;
+    uiElementID = circuit->getUIElementIDForUIElement((UIElement*) this);
     this->xGrid = xGrid;
     this->yGrid = yGrid;
 

--- a/src/UIElements/PMOSUIElement.h
+++ b/src/UIElements/PMOSUIElement.h
@@ -61,7 +61,7 @@ public:
 
       pmosElement = PMOSElement::create(
           k, va, vt, uiCircuit->getIDfromLoc(pin3Loc),
-          uiCircuit->getIDfromLoc(pin1Loc), uiCircuit->getIDfromLoc(pin2Loc));
+          uiCircuit->getIDfromLoc(pin2Loc), uiCircuit->getIDfromLoc(pin1Loc));
       std::cout << "PMOS Element Created!" << std::endl;
       std::cout << "PMOS UI Element added to UI Circuit. ID: " << uiElementID
                 << std::endl;
@@ -69,12 +69,11 @@ public:
     return pmosElement.get();
   }
 
-  void resetElement() override {
-    pmosElement.reset();
-  }
+  void resetElement() override { pmosElement.reset(); }
 
   void showElement(sf::RenderWindow *window) override {
-    if (pmosElement.get() == nullptr || uiCircuit->getDisplayCircuit() == nullptr) {
+    if (pmosElement.get() == nullptr ||
+        uiCircuit->getDisplayCircuit() == nullptr) {
       PMOSUIElement::showGhostElement(window, xGrid, yGrid);
       // ghost version
     } else {
@@ -96,8 +95,8 @@ public:
             pmosElement->getPIN_S());
       }
 
-      double id =
-          pmosElement->getId(uiCircuit->getDisplayCircuit()->getVoltageMatrix());
+      double id = pmosElement->getId(
+          uiCircuit->getDisplayCircuit()->getVoltageMatrix());
       shownPinGVolt = pinGVolt;
       shownPinDVolt = pinDVolt;
       shownPinSVolt = pinSVolt;
@@ -124,18 +123,19 @@ private:
   static void showPMOS(sf::RenderWindow *window, sf::Vector2f &loc, double vg,
                        double vd, double vs) {
     double width = 5;
-    sf::Vector2f pointD1(loc.x, loc.y - 50);
-    sf::Vector2f pointD2(loc.x, loc.y - 25);
+
+    sf::Vector2f pointS1(loc.x, loc.y - 50);
+    sf::Vector2f pointS2(loc.x, loc.y - 25);
+    sf::Vector2f pointB11(loc.x - 50 + 2.5 + 10, loc.y - 25 + 10);
+    sf::Vector2f pointB12(loc.x - 50 + 2.5 + 10, loc.y - 25 - 10);
     sf::Vector2f pointB1(loc.x - 50 + 2.5, loc.y - 25);
     sf::Vector2f pointB2(loc.x - 50 + 2.5, loc.y + 25);
     sf::Vector2f pointBG1(loc.x - 50 - 7.5, loc.y - 25);
     sf::Vector2f pointBG2(loc.x - 50 - 7.5, loc.y + 25);
     sf::Vector2f pointG1(loc.x - 50 - 7.5, loc.y);
     sf::Vector2f pointG2(loc.x - 100, loc.y);
-    sf::Vector2f pointS1(loc.x, loc.y + 25);
-    sf::Vector2f pointS11(loc.x - 10, loc.y + 25 + 10);
-    sf::Vector2f pointS12(loc.x - 10, loc.y + 25 - 10);
-    sf::Vector2f pointS2(loc.x, loc.y + 50);
+    sf::Vector2f pointD1(loc.x, loc.y + 25);
+    sf::Vector2f pointD2(loc.x, loc.y + 50);
 
     sf::Color gColor;
     voltToColor(vg, gColor);
@@ -146,15 +146,15 @@ private:
     sf::Color bColor;
     midColor(bColor, dColor, sColor);
 
-    showLine(window, pointD1, pointD2, 5, dColor, dColor, dColor);
-    showLine(window, pointB1, pointB2, width, dColor, sColor, bColor);
+    showLine(window, pointS1, pointS2, 5, sColor, sColor, sColor);
+    showLine(window, pointB1, pointB2, width, sColor, dColor, bColor);
     showLine(window, pointBG1, pointBG2, width, gColor, gColor, gColor);
     showLine(window, pointG1, pointG2, 5, gColor, gColor, gColor);
-    showLine(window, pointS1, pointS2, 5, sColor, sColor, sColor);
-    showLine(window, pointD2, pointB1, 5, dColor, dColor, dColor);
-    showLine(window, pointB2, pointS1, 5, sColor, sColor, sColor);
-    showLine(window, pointS1, pointS11, width, sColor, sColor, sColor);
-    showLine(window, pointS1, pointS12, width, sColor, sColor, sColor);
+    showLine(window, pointD1, pointD2, 5, dColor, dColor, dColor);
+    showLine(window, pointS2, pointB1, 5, sColor, sColor, sColor);
+    showLine(window, pointB2, pointD1, 5, dColor, dColor, dColor);
+    showLine(window, pointB1, pointB11, width, sColor, sColor, sColor);
+    showLine(window, pointB1, pointB12, width, sColor, sColor, sColor);
   }
   void showPMOS(sf::RenderWindow *window, double vg, double vd, double vs,
                 double id, sf::Vector2f &loc, double currentScale) {
@@ -165,18 +165,18 @@ private:
     double width = 5;
 
     PMOSUIElement::showPMOS(window, loc, vg, vd, vs);
-    sf::Vector2f pointD1(loc.x, loc.y - 50);
-    sf::Vector2f pointD2(loc.x, loc.y - 25);
+    sf::Vector2f pointS1(loc.x, loc.y - 50);
+    sf::Vector2f pointS2(loc.x, loc.y - 25);
+    sf::Vector2f pointB11(loc.x - 50 + 2.5 + 10, loc.y - 25 + 10);
+    sf::Vector2f pointB12(loc.x - 50 + 2.5 + 10, loc.y - 25 - 10);
     sf::Vector2f pointB1(loc.x - 50 + 2.5, loc.y - 25);
     sf::Vector2f pointB2(loc.x - 50 + 2.5, loc.y + 25);
     sf::Vector2f pointBG1(loc.x - 50 - 7.5, loc.y - 25);
     sf::Vector2f pointBG2(loc.x - 50 - 7.5, loc.y + 25);
     sf::Vector2f pointG1(loc.x - 50 - 7.5, loc.y);
     sf::Vector2f pointG2(loc.x - 100, loc.y);
-    sf::Vector2f pointS1(loc.x, loc.y + 25);
-    sf::Vector2f pointS11(loc.x - 10, loc.y + 25 + 10);
-    sf::Vector2f pointS12(loc.x - 10, loc.y + 25 - 10);
-    sf::Vector2f pointS2(loc.x, loc.y + 50);
+    sf::Vector2f pointD1(loc.x, loc.y + 25);
+    sf::Vector2f pointD2(loc.x, loc.y + 50);
 
     double &current = id;
     // std::cout << "id:" << id << std::endl;
@@ -195,25 +195,25 @@ private:
 
     for (int i = 0; i < 20; ++i) {
       if (i < 1)
-        circle.setPosition(pointD1.x - circle.getRadius(),
-                           pointD1.y - circle.getRadius() + lastoffsetPMOS);
+        circle.setPosition(pointS1.x - circle.getRadius(),
+                           pointS1.y - circle.getRadius() + lastoffsetPMOS);
       else if (i < 2) {
         if (lastoffsetPMOS < 5)
-          circle.setPosition(pointD1.x - circle.getRadius(),
-                             pointD1.y + 20 - circle.getRadius() +
+          circle.setPosition(pointS1.x - circle.getRadius(),
+                             pointS1.y + 20 - circle.getRadius() +
                                  lastoffsetPMOS);
         else
-          circle.setPosition(pointD2.x - circle.getRadius() - lastoffsetPMOS +
+          circle.setPosition(pointS2.x - circle.getRadius() - lastoffsetPMOS +
                                  5,
-                             pointD2.y - circle.getRadius());
+                             pointS2.y - circle.getRadius());
       } else if (i < 3) {
-        circle.setPosition(pointD2.x - circle.getRadius() - lastoffsetPMOS - 15,
-                           pointD2.y - circle.getRadius());
+        circle.setPosition(pointS2.x - circle.getRadius() - lastoffsetPMOS - 15,
+                           pointS2.y - circle.getRadius());
       } else if (i < 4) {
         if (lastoffsetPMOS < 15)
-          circle.setPosition(pointD2.x - circle.getRadius() - lastoffsetPMOS -
+          circle.setPosition(pointS2.x - circle.getRadius() - lastoffsetPMOS -
                                  35,
-                             pointD2.y - circle.getRadius());
+                             pointS2.y - circle.getRadius());
         else
           circle.setPosition(pointB1.x - circle.getRadius(),
                              pointB1.y - circle.getRadius() + lastoffsetPMOS -
@@ -240,12 +240,12 @@ private:
                                  35,
                              pointB2.y - circle.getRadius());
         else
-          circle.setPosition(pointS1.x - circle.getRadius(),
-                             pointS1.y - circle.getRadius() - 15 +
+          circle.setPosition(pointD1.x - circle.getRadius(),
+                             pointD1.y - circle.getRadius() - 15 +
                                  lastoffsetPMOS);
       } else {
-        circle.setPosition(pointS1.x - circle.getRadius(),
-                           pointS1.y - circle.getRadius() + lastoffsetPMOS + 5);
+        circle.setPosition(pointD1.x - circle.getRadius(),
+                           pointD1.y - circle.getRadius() + lastoffsetPMOS + 5);
       }
       circle.setFillColor(sf::Color(200, 200, 0));
       window->draw(circle);

--- a/src/UIElements/PMOSUIElement.h
+++ b/src/UIElements/PMOSUIElement.h
@@ -1,0 +1,260 @@
+#pragma once
+#include "Circuit.h"
+#include "Line.h"
+#include "PMOSElement.h"
+#include "UIElement.h"
+#include <SFML/Graphics.hpp>
+#include <SFML/Graphics/RenderWindow.hpp>
+#include <UICircuit.h>
+#include <iostream>
+
+class PMOSUIElement : public UIElement {
+public:
+  static void showGhostElement(sf::RenderWindow *window, int xGrid, int yGrid) {
+    sf::Vector2f loc(xGrid * 50, yGrid * 50);
+    PMOSUIElement::showPMOS(window, loc, 0, 0, 0);
+  }
+
+private:
+  std::unique_ptr<PMOSElement> pmosElement;
+  double k, va, vt;
+
+public:
+  ~PMOSUIElement() override {};
+  PMOSUIElement(UICircuit *circuit, int xGrid, int yGrid, double k, double vt,
+                double va) {
+    uiCircuit = circuit;
+    this->xGrid = xGrid;
+    this->yGrid = yGrid;
+
+    this->k = k;
+    this->vt = vt;
+    this->va = va;
+
+    std::string pin1Loc =
+        std::to_string(xGrid) + "," + std::to_string(yGrid - 1);
+    std::string pin2Loc =
+        std::to_string(xGrid) + "," + std::to_string(yGrid + 1);
+    std::string pin3Loc =
+        std::to_string(xGrid - 2) + "," + std::to_string(yGrid);
+
+    this->connectedLocs.push_back(pin1Loc);
+    this->connectedLocs.push_back(pin2Loc);
+    this->connectedLocs.push_back(pin3Loc);
+
+    this->noCurrentLocs.push_back(pin3Loc);
+
+    std::cout << "PMOS Init: " << std::endl;
+    std::cout << "  Pin1Loc: " << pin1Loc << std::endl;
+    std::cout << "  Pin2Loc: " << pin2Loc << std::endl;
+    std::cout << "  Pin3Loc: " << pin3Loc << std::endl;
+  }
+
+  CircuitElement *getCircuitElementPointer() override {
+    if (pmosElement.get() == nullptr) {
+      std::string pin1Loc =
+          std::to_string(xGrid) + "," + std::to_string(yGrid - 1);
+      std::string pin2Loc =
+          std::to_string(xGrid) + "," + std::to_string(yGrid + 1);
+      std::string pin3Loc =
+          std::to_string(xGrid - 2) + "," + std::to_string(yGrid);
+
+      pmosElement = PMOSElement::create(
+          k, va, vt, uiCircuit->getIDfromLoc(pin3Loc),
+          uiCircuit->getIDfromLoc(pin1Loc), uiCircuit->getIDfromLoc(pin2Loc));
+      std::cout << "PMOS Element Created!" << std::endl;
+      std::cout << "PMOS UI Element added to UI Circuit. ID: " << uiElementID
+                << std::endl;
+    }
+    return pmosElement.get();
+  }
+
+  void resetElement() override {
+    pmosElement.reset();
+  }
+
+  void showElement(sf::RenderWindow *window) override {
+    if (pmosElement.get() == nullptr || uiCircuit->getDisplayCircuit() == nullptr) {
+      PMOSUIElement::showGhostElement(window, xGrid, yGrid);
+      // ghost version
+    } else {
+      double pinGVolt = 0;
+      double pinDVolt = 0;
+      double pinSVolt = 0;
+      if (pmosElement->getPIN_G() != -1) {
+        pinGVolt = *uiCircuit->getDisplayCircuit()->getVoltagePointer(
+            pmosElement->getPIN_G());
+      }
+
+      if (pmosElement->getPIN_D() != -1) {
+        pinDVolt = *uiCircuit->getDisplayCircuit()->getVoltagePointer(
+            pmosElement->getPIN_D());
+      }
+
+      if (pmosElement->getPIN_S() != -1) {
+        pinSVolt = *uiCircuit->getDisplayCircuit()->getVoltagePointer(
+            pmosElement->getPIN_S());
+      }
+
+      double id =
+          pmosElement->getId(uiCircuit->getDisplayCircuit()->getVoltageMatrix());
+      shownPinGVolt = pinGVolt;
+      shownPinDVolt = pinDVolt;
+      shownPinSVolt = pinSVolt;
+      shownId = id;
+      showPMOS(window, pinGVolt, pinDVolt, pinSVolt, id, xGrid, yGrid,
+               uiCircuit->getCurrentScale());
+    }
+  }
+
+private:
+  double shownPinGVolt;
+  double shownPinDVolt;
+  double shownPinSVolt;
+  double shownId;
+
+public:
+  double getShownPinGVolt() { return shownPinGVolt; }
+  double getShownPinDVolt() { return shownPinDVolt; }
+  double getShownPinSVolt() { return shownPinSVolt; }
+  double getShownId() { return shownId; }
+
+private:
+  double lastoffsetPMOS = 0;
+  static void showPMOS(sf::RenderWindow *window, sf::Vector2f &loc, double vg,
+                       double vd, double vs) {
+    double width = 5;
+    sf::Vector2f pointD1(loc.x, loc.y - 50);
+    sf::Vector2f pointD2(loc.x, loc.y - 25);
+    sf::Vector2f pointB1(loc.x - 50 + 2.5, loc.y - 25);
+    sf::Vector2f pointB2(loc.x - 50 + 2.5, loc.y + 25);
+    sf::Vector2f pointBG1(loc.x - 50 - 7.5, loc.y - 25);
+    sf::Vector2f pointBG2(loc.x - 50 - 7.5, loc.y + 25);
+    sf::Vector2f pointG1(loc.x - 50 - 7.5, loc.y);
+    sf::Vector2f pointG2(loc.x - 100, loc.y);
+    sf::Vector2f pointS1(loc.x, loc.y + 25);
+    sf::Vector2f pointS11(loc.x - 10, loc.y + 25 + 10);
+    sf::Vector2f pointS12(loc.x - 10, loc.y + 25 - 10);
+    sf::Vector2f pointS2(loc.x, loc.y + 50);
+
+    sf::Color gColor;
+    voltToColor(vg, gColor);
+    sf::Color dColor;
+    voltToColor(vd, dColor);
+    sf::Color sColor;
+    voltToColor(vs, sColor);
+    sf::Color bColor;
+    midColor(bColor, dColor, sColor);
+
+    showLine(window, pointD1, pointD2, 5, dColor, dColor, dColor);
+    showLine(window, pointB1, pointB2, width, dColor, sColor, bColor);
+    showLine(window, pointBG1, pointBG2, width, gColor, gColor, gColor);
+    showLine(window, pointG1, pointG2, 5, gColor, gColor, gColor);
+    showLine(window, pointS1, pointS2, 5, sColor, sColor, sColor);
+    showLine(window, pointD2, pointB1, 5, dColor, dColor, dColor);
+    showLine(window, pointB2, pointS1, 5, sColor, sColor, sColor);
+    showLine(window, pointS1, pointS11, width, sColor, sColor, sColor);
+    showLine(window, pointS1, pointS12, width, sColor, sColor, sColor);
+  }
+  void showPMOS(sf::RenderWindow *window, double vg, double vd, double vs,
+                double id, sf::Vector2f &loc, double currentScale) {
+    // pin_d 100 100
+    // pin_g 0 150
+    // pin_s 100 200
+    // loc 100 150
+    double width = 5;
+
+    PMOSUIElement::showPMOS(window, loc, vg, vd, vs);
+    sf::Vector2f pointD1(loc.x, loc.y - 50);
+    sf::Vector2f pointD2(loc.x, loc.y - 25);
+    sf::Vector2f pointB1(loc.x - 50 + 2.5, loc.y - 25);
+    sf::Vector2f pointB2(loc.x - 50 + 2.5, loc.y + 25);
+    sf::Vector2f pointBG1(loc.x - 50 - 7.5, loc.y - 25);
+    sf::Vector2f pointBG2(loc.x - 50 - 7.5, loc.y + 25);
+    sf::Vector2f pointG1(loc.x - 50 - 7.5, loc.y);
+    sf::Vector2f pointG2(loc.x - 100, loc.y);
+    sf::Vector2f pointS1(loc.x, loc.y + 25);
+    sf::Vector2f pointS11(loc.x - 10, loc.y + 25 + 10);
+    sf::Vector2f pointS12(loc.x - 10, loc.y + 25 - 10);
+    sf::Vector2f pointS2(loc.x, loc.y + 50);
+
+    double &current = id;
+    // std::cout << "id:" << id << std::endl;
+    lastoffsetPMOS += current * currentScale;
+    lastoffsetPMOS = std::remainder(lastoffsetPMOS, 20);
+    lastoffsetPMOS =
+        lastoffsetPMOS < 0 ? lastoffsetPMOS + 20.0 : lastoffsetPMOS;
+
+    sf::CircleShape circle(width / 2);
+    for (int i = 0; i < 2; ++i) {
+      circle.setPosition(pointG1.x - circle.getRadius() - 20 * i,
+                         pointG1.y - circle.getRadius());
+      circle.setFillColor(sf::Color(200, 200, 0));
+      window->draw(circle);
+    }
+
+    for (int i = 0; i < 20; ++i) {
+      if (i < 1)
+        circle.setPosition(pointD1.x - circle.getRadius(),
+                           pointD1.y - circle.getRadius() + lastoffsetPMOS);
+      else if (i < 2) {
+        if (lastoffsetPMOS < 5)
+          circle.setPosition(pointD1.x - circle.getRadius(),
+                             pointD1.y + 20 - circle.getRadius() +
+                                 lastoffsetPMOS);
+        else
+          circle.setPosition(pointD2.x - circle.getRadius() - lastoffsetPMOS +
+                                 5,
+                             pointD2.y - circle.getRadius());
+      } else if (i < 3) {
+        circle.setPosition(pointD2.x - circle.getRadius() - lastoffsetPMOS - 15,
+                           pointD2.y - circle.getRadius());
+      } else if (i < 4) {
+        if (lastoffsetPMOS < 15)
+          circle.setPosition(pointD2.x - circle.getRadius() - lastoffsetPMOS -
+                                 35,
+                             pointD2.y - circle.getRadius());
+        else
+          circle.setPosition(pointB1.x - circle.getRadius(),
+                             pointB1.y - circle.getRadius() + lastoffsetPMOS -
+                                 15);
+      } else if (i < 6) {
+        circle.setPosition(pointB1.x - circle.getRadius(),
+                           pointB1.y - circle.getRadius() + lastoffsetPMOS + 5 +
+                               (i - 4) * 20);
+      } else if (i < 7) {
+        if (lastoffsetPMOS < 5)
+          circle.setPosition(pointB1.x - circle.getRadius(),
+                             pointB1.y - circle.getRadius() + lastoffsetPMOS +
+                                 45);
+        else
+          circle.setPosition(pointB2.x - circle.getRadius() + lastoffsetPMOS -
+                                 5,
+                             pointB2.y - circle.getRadius());
+      } else if (i < 8) {
+        circle.setPosition(pointB2.x - circle.getRadius() + lastoffsetPMOS + 15,
+                           pointB2.y - circle.getRadius());
+      } else if (i < 9) {
+        if (lastoffsetPMOS < 15)
+          circle.setPosition(pointB2.x - circle.getRadius() + lastoffsetPMOS +
+                                 35,
+                             pointB2.y - circle.getRadius());
+        else
+          circle.setPosition(pointS1.x - circle.getRadius(),
+                             pointS1.y - circle.getRadius() - 15 +
+                                 lastoffsetPMOS);
+      } else {
+        circle.setPosition(pointS1.x - circle.getRadius(),
+                           pointS1.y - circle.getRadius() + lastoffsetPMOS + 5);
+      }
+      circle.setFillColor(sf::Color(200, 200, 0));
+      window->draw(circle);
+    }
+  }
+
+  void showPMOS(sf::RenderWindow *window, double vg, double vd, double vs,
+                double id, int xGrid, int yGrid, double currentScale) {
+    sf::Vector2f loc(xGrid * 50, yGrid * 50);
+    showPMOS(window, vg, vd, vs, id, loc, currentScale);
+  }
+};

--- a/src/UIElements/ResistorUIElement.h
+++ b/src/UIElements/ResistorUIElement.h
@@ -21,6 +21,7 @@ private:
 
 public:
   ResistorUIElement(UICircuit *circuit, int xGrid, int yGrid, double R) {
+    uiElementID = circuit->getUIElementIDForUIElement((UIElement*) this);
     uiCircuit = circuit;
     this->R = R;
     this->xGrid = xGrid;

--- a/src/UIElements/VoltageSourceUIElement.h
+++ b/src/UIElements/VoltageSourceUIElement.h
@@ -24,6 +24,7 @@ public:
   ~VoltageSourceUIElement() override {};
   VoltageSourceUIElement(UICircuit *circuit, int xGrid, int yGrid, double v) {
     // important
+    uiElementID = circuit->getUIElementIDForUIElement((UIElement*) this);
     uiCircuit = circuit;
     this->xGrid = xGrid;
     this->yGrid = yGrid;

--- a/src/UIElements/WireUIElement.h
+++ b/src/UIElements/WireUIElement.h
@@ -90,6 +90,7 @@ public:
       std::cout << "Wire UI Element added to UI Circuit. ID: " << uiElementID << std::endl;
     }
     return element.get();
+
   }
 
   void resetElement() override {

--- a/src/UIElements/WireUIElement.h
+++ b/src/UIElements/WireUIElement.h
@@ -25,6 +25,7 @@ public:
   ~WireUIElement() override {};
   WireUIElement(UICircuit *circuit, int xGrid1, int yGrid1, int xGrid2,
                 int yGrid2) {
+    uiElementID = circuit->getUIElementIDForUIElement((UIElement*) this);
     uiCircuit = circuit;
     this->xGrid = -1;
     this->yGrid = -1;


### PR DESCRIPTION
新加的元件： 電容(c) PMOS(p) 電流源(i) 電感(I) 二極體(d)
更改元件: NMOS PMOS 使用 GMIN 增加線性度, Capacitor Inductor 使用 trapezoidal
uiElementID 做一點修正保證內部節點也可以加入模擬
牛頓法將太離譜的deltaV限制住 (ex. 10^6 -> 1.34)
按住C鍵後對網格交點點左鍵可以放置電容元件 不能旋轉 其他元件差不多同樣放置方式
按住S鍵對畫面點左鍵可以啟動模擬